### PR TITLE
Add spacing between table tool bar and table headers

### DIFF
--- a/src/renderer/containers/CustomDataTable/TableToolHeader/styles.pcss
+++ b/src/renderer/containers/CustomDataTable/TableToolHeader/styles.pcss
@@ -4,5 +4,6 @@
     border-top: var(--border);
     border-left: var(--border);
     border-right: var(--border);
+    padding-bottom: 0.5em;
     padding-left: 2em;
 }


### PR DESCRIPTION
Jamie was accidentally clicking a table header thereby sorting the table rather than the mass edit button which was annoying. This just adds a little space between those two. Cleared new spacing with Jamie.

![image](https://user-images.githubusercontent.com/41307451/131543166-bbde91a1-0ba0-428a-b791-d70a4f833033.png)