### PR TITLE
Retrieve plate barcode mapping from draft state

### DIFF
--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -804,6 +804,7 @@ const openUploadLogic = createLogic({
     const { draft } = ctx;
     const uploadFilesFromDraft = getUpload(draft);
     try {
+      dispatch(setPlateBarcodeToPlates(getPlateBarcodeToPlates(draft)));
       dispatch(addUploadFiles(Object.values(uploadFilesFromDraft)));
     } catch (e) {
       dispatch(setErrorAlert(`Encountered error while resolving files: ${e}`));


### PR DESCRIPTION
Tanya reported a bug with opening an upload draft that contains wells. The app was not retrieving the plate barcode to well mappings that the draft was saved with.