### PR TITLE
[UR-23] Fix SubFileSelectionModal so it repopulates with existing data

### DIFF
--- a/src/renderer/containers/SubFileSelectionModal/index.tsx
+++ b/src/renderer/containers/SubFileSelectionModal/index.tsx
@@ -29,7 +29,7 @@ function SubFileSelectionModal({ file }: { file: string }) {
 
   // Determine initial state from corresponding upload row
   const row = React.useMemo(() => {
-    const row = uploads.find(({ key }) => key === file);
+    const row = uploads.find(({ file: fileName }) => fileName === file);
     let initialSubImageType;
     if (!isEmpty(row?.subImageNames)) {
       initialSubImageType = SubImageType.GENERIC;


### PR DESCRIPTION
We want the file sub-scene, -channel, -position, w/e selector modal to populate with data that's already present in the metadata grid if a user goes back to use it a second time. Turns out this was already implemented, but we had renamed an object attribute at some point.