### PR TITLE
Keep column widths between tables

### DIFF
--- a/src/renderer/containers/CustomDataTable/index.tsx
+++ b/src/renderer/containers/CustomDataTable/index.tsx
@@ -127,9 +127,18 @@ export default function CustomDataTable({ hasSubmitBeenAttempted }: Props) {
     return null;
   }
 
+  // Map columns to their widths to persist the widths in the MassEditTable as well
+  const columnToWidthMap = tableInstance.allColumns.reduce(
+    (mapSoFar, column) => ({
+      ...mapSoFar,
+      [column.id]: column.width,
+    }),
+    {}
+  );
+
   return (
     <>
-      {isMassEditing && <MassEditTable />}
+      {isMassEditing && <MassEditTable columnToWidthMap={columnToWidthMap} />}
       <TableToolHeader selectedRows={tableInstance.selectedFlatRows || []} />
       <Table tableInstance={tableInstance} />
       <TableFooter />


### PR DESCRIPTION
Becky reported that the data entry table in the File Upload App does not persist user adjusted column widths to the secondary table that pops up for mass editing. This PR simply extracts the widths and passes them along. Confirmed with Becky this was the intended feature

https://user-images.githubusercontent.com/41307451/150174721-951a4055-f30c-4713-9c35-f97b885b2ce0.mov

