### PR TITLE
check FSS2 (instead of LK) by name and size

### DIFF
--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -30,7 +30,6 @@ interface FileManagementClientConfig {
   fileReader: ChunkedFileReader;
   fss: FileStorageService;
   jss: JobStatusService;
-  lk: LabkeyClient;
   mms: MetadataManagementService;
 }
 
@@ -49,7 +48,6 @@ export default class FileManagementSystem {
   private readonly fileReader: ChunkedFileReader;
   private readonly fss: FileStorageService;
   private readonly jss: JobStatusService;
-  private readonly lk: LabkeyClient;
   private readonly mms: MetadataManagementService;
 
   private static readonly CHUNKS_INFLIGHT_REQUEST_MEMORY_USAGE_MAX = 40 * 1024 * 1024; // 40 mb
@@ -86,7 +84,6 @@ export default class FileManagementSystem {
     this.fileReader = config.fileReader;
     this.fss = config.fss;
     this.jss = config.jss;
-    this.lk = config.lk;
     this.mms = config.mms;
   }
 
@@ -151,7 +148,7 @@ export default class FileManagementSystem {
       }
 
       // Prevent attempting to upload a duplicate
-      if (await this.lk.fileExistsByNameAndMD5(fileName, md5)) {
+      if (await this.fss.fileExistsByNameAndSize(fileName, fileSize)) {
         throw new Error(
           `File ${fileName} with MD5 ${md5} already exists in LabKey`
         );

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -20,7 +20,6 @@ import {
   UploadServiceFields,
   Service,
 } from "../job-status-service/types";
-import LabkeyClient from "../labkey-client";
 import MetadataManagementService from "../metadata-management-service";
 import { UploadRequest } from "../types";
 

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -149,7 +149,7 @@ export default class FileManagementSystem {
       // Heuristic which in most cases, prevents attempting to upload a duplicate
       if (await this.fss.fileExistsByNameAndSize(fileName, fileSize)) {
         throw new Error(
-          `File ${fileName} with MD5 ${md5} already exists in LabKey`
+          `File ${fileName} with size ${fileSize} already exists in FMS`
         );
       }
 

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -146,7 +146,7 @@ export default class FileManagementSystem {
         );
       }
 
-      // Prevent attempting to upload a duplicate
+      // Heuristic which in most cases, prevents attempting to upload a duplicate
       if (await this.fss.fileExistsByNameAndSize(fileName, fileSize)) {
         throw new Error(
           `File ${fileName} with MD5 ${md5} already exists in LabKey`

--- a/src/renderer/services/file-management-system/test/file-management-system.test.ts
+++ b/src/renderer/services/file-management-system/test/file-management-system.test.ts
@@ -36,10 +36,10 @@ describe("FileManagementSystem", () => {
   let mms: SinonStubbedInstance<MetadataManagementService>;
   let fms: FileManagementSystem;
   const testFilePath = path.resolve(os.tmpdir(), "md5-test.txt");
-  const testFileSize = 1024 * 1024 * 2;
+  const testFileSize = 1024 * 1024 * 2; //2MB
 
   before(async () => {
-    // Generate file with 2MB of "random" bytes
+    // Generate file with testFileSize of "random" bytes
     await fs.promises.writeFile(
       testFilePath,
       Buffer.allocUnsafe(testFileSize)

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -87,7 +87,7 @@ export default class FileStorageService extends HttpCacheClient {
   ): Promise<boolean> {
     const url = `${FileStorageService.BASE_FILE_PATH}?name=${name}&size=${size}`;
     const fileRecords = await this.get<FileRecord[]>(url);
-    return fileRecords.length != 0;
+    return fileRecords.length !== 0;
   }
 
   /**

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -81,6 +81,15 @@ export default class FileStorageService extends HttpCacheClient {
     super(httpClient, localStorage, false);
   }
 
+  public async fileExistsByNameAndSize(
+    name: string,
+    size: number
+  ): Promise<boolean> {
+    const url = `${FileStorageService.BASE_FILE_PATH}?name=${name}&size=${size}`;
+    const fileRecords = await this.get<FileRecord[]>(url);
+    return fileRecords.length != 0;
+  }
+
   /**
    * This is the first step to an upload. Before the app can start sending
    * chunks of the file to upload it must first make the service aware of the

--- a/src/renderer/state/configure-store.ts
+++ b/src/renderer/state/configure-store.ts
@@ -104,7 +104,6 @@ export const reduxLogicDependencies: Partial<ReduxLogicExtraDependencies> = {
     fileReader: new ChunkedFileReader(),
     fss: new FileStorageService(httpClient, storage),
     jss: jssClient,
-    lk: labkeyClient,
     mms: mmsClient,
   }),
   ipcRenderer,


### PR DESCRIPTION
**Background:** Currently, FUA checks if a file already exists in FMS by looking it up in LK by name and md5.  In order to refactor the md5 to be passed into `/finalize` instead of `/register` (necessary for performance goals), we need to change this lookup so that the md5 can be computed later in the workflow.

**Objective:**  This PR changes the LK lookup to an FSS2 lookup by name and size.  This is a heuristic which will prevent most, but not all duplicate uploads.  For cases where the name and size already exist, but the file contents are different, the upload will be allowed to proceed, but will fail on /finalize.

Related: https://github.com/aics-int/file-storage-service/pull/128