### PR TITLE
Update callback for date selection

### DIFF
--- a/src/renderer/containers/Table/Editors/DateEditor/index.tsx
+++ b/src/renderer/containers/Table/Editors/DateEditor/index.tsx
@@ -55,7 +55,7 @@ export default function DateEditor({
         showTime={column.type === ColumnType.DATETIME}
         placeholder="Add a Date"
         value={value ? moment(value) : undefined}
-        onChange={(d) => setValue(d?.toDate() ?? undefined)}
+        onSelect={(selectedValue) => setValue(selectedValue?.toDate() ?? undefined)}
         renderExtraFooter={() => (
           <div className={styles.footer}>
             <Button


### PR DESCRIPTION
The way the `onChange()` is used changed in a version upgrade for the corresponding component library, this utilizes `onSelect` now instead.