### PR TITLE
Bugfix/swe 308

### DIFF
--- a/src/renderer/services/file-management-system/test/file-management-system.test.ts
+++ b/src/renderer/services/file-management-system/test/file-management-system.test.ts
@@ -478,7 +478,7 @@ describe("FileManagementSystem", () => {
 
     [UploadStage.ADDING_CHUNKS, UploadStage.WAITING_FOR_FIRST_CHUNK].forEach(
       (stage) => {
-        it(`resumes sending chunks for an upload with some chunks already been sent, and an active FSS status for stage ${stage}`, async () => {
+        it(`resumes sending chunks for an upload. Said upload has some chunks uploaded already, and is in an active FSS status for stage ${stage}`, async () => {
           // Arrange
           const uploadId = "234124141";
           const upload: UploadJob = {

--- a/src/renderer/services/file-management-system/test/file-management-system.test.ts
+++ b/src/renderer/services/file-management-system/test/file-management-system.test.ts
@@ -478,7 +478,7 @@ describe("FileManagementSystem", () => {
 
     [UploadStage.ADDING_CHUNKS, UploadStage.WAITING_FOR_FIRST_CHUNK].forEach(
       (stage) => {
-        it.only(`resumes sending chunks for an upload with some chunks already been sent, and an active FSS status for stage ${stage}`, async () => {
+        it(`resumes sending chunks for an upload with some chunks already been sent, and an active FSS status for stage ${stage}`, async () => {
           // Arrange
           const uploadId = "234124141";
           const upload: UploadJob = {

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -23,17 +23,17 @@ export interface FSSUpload extends JSSJob {
 
 export enum UploadStatus {
   WORKING = "WORKING", // as expected, in process
-  FAILED = "FAILED", // software failure
   COMPLETE = "COMPLETE",
+  FAILED = "FAILED", // software failure
   CANCELLED = "CANCELLED", // user cancelled
   EXPIRED = "EXPIRED", // too long since last activity
 }
 
 export enum ChunkStatus {
-  ALLOCATED = "Allocated",
-  WORKING = "Working",
-  FAILED = "Failed",
-  COMPLETE = "Complete",
+  FAILED = "FAILED",
+  WORKING = "WORKING",
+  CORRUPT = "CORRUPT",
+  COMPLETE = "COMPLETE",
 }
 
 export enum UploadStage {


### PR DESCRIPTION
**Purpose**:
Fix breaking changes which affect resume upload functionality (against FSS2).

**Changes**:
Updates the string values expected to be returned from FSS2, which changed in this [pr](https://github.com/aics-int/file-storage-service/pull/143/files#diff-944509ca3b449ed1afcaa574c89428b19f808e7d04c96548d104d912ae6bf388)

**How to review: where should reviewers look?**
`ChunkStatus`

**How I tested**
* Created an upload which failed on chunk 3 (inserted test code to throw error).  Then on this branch, resumed the failed upload.  Chunks resumed sending on chunk 3 based on the chunk statuses returned by FSS2 (GET /upload).
* Added a unit test covering this scenario.


Related PR:
https://github.com/aics-int/aicsfiles-python/pull/49