### PR TITLE
[SWE-335] Fix slow queries for FMS.File lookup annotations 

### DIFF
--- a/src/renderer/@types/react-table-config.d.ts
+++ b/src/renderer/@types/react-table-config.d.ts
@@ -33,6 +33,8 @@ interface CustomColumnProps {
   isRequired?: boolean;
   hasSubmitBeenAttempted?: boolean;
   type?: ColumnType;
+  lookupSchema?: string;
+  lookupTable?: string;
 }
 
 // Config for `react-table` types. More info here:

--- a/src/renderer/containers/CustomDataTable/selectors.tsx
+++ b/src/renderer/containers/CustomDataTable/selectors.tsx
@@ -28,7 +28,10 @@ const MAX_HEADER_WIDTH = 200;
 // Determine best width for column based on its type and header name
 // tries to account for the header text width up to an upper limit
 // to prevent extreme widths
-function getColumnWidthForType(column: string, type?: ColumnType): number {
+export function getColumnWidthForType(
+  column: string,
+  type?: ColumnType
+): number {
   // Find the max width between the words in the column header
   // so we can prevent words from breaking into pieces
   const maxWidth = column

--- a/src/renderer/containers/CustomDataTable/selectors.tsx
+++ b/src/renderer/containers/CustomDataTable/selectors.tsx
@@ -154,13 +154,24 @@ export const getTemplateColumnsForTable = createSelector(
           const type = annotationTypes.find(
             (type) => type.annotationTypeId === annotation.annotationTypeId
           )?.name;
-          return {
+          const standardReturn = {
             type,
             accessor: annotation.name,
             description: annotation.description,
             dropdownValues: annotation.annotationOptions,
             isRequired: annotation.required,
             width: getColumnWidthForType(annotation.name, type),
+          };
+          let lookupTypeAttributes = {};
+          if (type === ColumnType.LOOKUP) {
+            lookupTypeAttributes = {
+              lookupSchema: annotation.lookupSchema,
+              lookupTable: annotation.lookupTable,
+            };
+          }
+          return {
+            ...standardReturn,
+            ...lookupTypeAttributes,
           };
         }),
     ];

--- a/src/renderer/containers/CustomDataTable/selectors.tsx
+++ b/src/renderer/containers/CustomDataTable/selectors.tsx
@@ -157,23 +157,20 @@ export const getTemplateColumnsForTable = createSelector(
           const type = annotationTypes.find(
             (type) => type.annotationTypeId === annotation.annotationTypeId
           )?.name;
-          const standardReturn = {
+          const lookupTypeAttributes =
+            type === ColumnType.LOOKUP
+              ? {
+                  lookupSchema: annotation.lookupSchema,
+                  lookupTable: annotation.lookupTable,
+                }
+              : null;
+          return {
             type,
             accessor: annotation.name,
             description: annotation.description,
             dropdownValues: annotation.annotationOptions,
             isRequired: annotation.required,
             width: getColumnWidthForType(annotation.name, type),
-          };
-          let lookupTypeAttributes = {};
-          if (type === ColumnType.LOOKUP) {
-            lookupTypeAttributes = {
-              lookupSchema: annotation.lookupSchema,
-              lookupTable: annotation.lookupTable,
-            };
-          }
-          return {
-            ...standardReturn,
             ...lookupTypeAttributes,
           };
         }),

--- a/src/renderer/containers/CustomDataTable/test/selectors.test.ts
+++ b/src/renderer/containers/CustomDataTable/test/selectors.test.ts
@@ -12,10 +12,10 @@ import {
   mockTemplateStateBranch,
 } from "../../../state/test/mocks";
 import {
-  getColumnsForTable,
-  getSelectedPlateBarcodes,
   getCanShowImagingSessionColumn,
   getCanShowWellColumn,
+  getColumnsForTable,
+  getSelectedPlateBarcodes,
   getTemplateColumnsForTable,
   PLATE_RELATED_COLUMNS,
 } from "../selectors";
@@ -29,17 +29,28 @@ describe("CustomDataTable selectors", () => {
     name,
     annotationTypeId: index,
   }));
+  const annotationTypeWidths = [150, 100, 84.49999999999999];
   const annotations = ["Cell Line", "Color", "Is Aligned"].map(
-    (name, index) => ({
-      ...mockAuditInfo,
-      annotationId: index,
-      name,
-      description: `${name} description`,
-      annotationTypeId: index === 0 ? 0 : 1,
-      orderIndex: index,
-      annotationOptions: [],
-      required: false,
-    })
+    (name, index) => {
+      const lookupTypeExtras =
+        index === 0
+          ? {
+              lookupSchema: "Celllines",
+              lookupTable: "Cell Line",
+            }
+          : null;
+      return {
+        ...mockAuditInfo,
+        annotationId: index,
+        name,
+        description: `${name} description`,
+        annotationTypeId: annotationTypes[index]["annotationTypeId"],
+        orderIndex: index,
+        annotationOptions: [],
+        required: false,
+        ...lookupTypeExtras,
+      };
+    }
   );
   const appliedTemplate = {
     ...mockMMSTemplate,
@@ -200,14 +211,24 @@ describe("CustomDataTable selectors", () => {
       expect(actual).to.be.lengthOf(6);
       expect(actual).deep.equal([
         ...PLATE_RELATED_COLUMNS,
-        ...annotations.map((a, index) => ({
-          type: index === 0 ? ColumnType.LOOKUP : ColumnType.TEXT,
-          accessor: a.name,
-          description: a.description,
-          dropdownValues: [],
-          isRequired: false,
-          width: index === 0 ? 150 : 100,
-        })),
+        ...annotations.map((a, index) => {
+          const lookupTypeExtras =
+            annotationTypes[index].name === ColumnType.LOOKUP
+              ? {
+                  lookupSchema: "Celllines",
+                  lookupTable: "Cell Line",
+                }
+              : null;
+          return {
+            type: annotationTypes[index].name,
+            accessor: a.name,
+            description: a.description,
+            dropdownValues: [],
+            isRequired: false,
+            width: annotationTypeWidths[index],
+            ...lookupTypeExtras,
+          };
+        }),
       ]);
     });
 

--- a/src/renderer/containers/CustomDataTable/test/selectors.test.ts
+++ b/src/renderer/containers/CustomDataTable/test/selectors.test.ts
@@ -15,6 +15,7 @@ import {
   getCanShowImagingSessionColumn,
   getCanShowWellColumn,
   getColumnsForTable,
+  getColumnWidthForType,
   getSelectedPlateBarcodes,
   getTemplateColumnsForTable,
   PLATE_RELATED_COLUMNS,
@@ -29,7 +30,6 @@ describe("CustomDataTable selectors", () => {
     name,
     annotationTypeId: index,
   }));
-  const annotationTypeWidths = [150, 100, 84.49999999999999];
   const annotations = ["Cell Line", "Color", "Is Aligned"].map(
     (name, index) => {
       const lookupTypeExtras =
@@ -212,6 +212,7 @@ describe("CustomDataTable selectors", () => {
       expect(actual).deep.equal([
         ...PLATE_RELATED_COLUMNS,
         ...annotations.map((a, index) => {
+          const type = annotationTypes[index].name;
           const lookupTypeExtras =
             annotationTypes[index].name === ColumnType.LOOKUP
               ? {
@@ -220,12 +221,12 @@ describe("CustomDataTable selectors", () => {
                 }
               : null;
           return {
-            type: annotationTypes[index].name,
+            type,
             accessor: a.name,
             description: a.description,
             dropdownValues: [],
             isRequired: false,
-            width: annotationTypeWidths[index],
+            width: getColumnWidthForType(a.name, type),
             ...lookupTypeExtras,
           };
         }),

--- a/src/renderer/containers/LookupSearch/index.tsx
+++ b/src/renderer/containers/LookupSearch/index.tsx
@@ -33,6 +33,7 @@ interface OwnProps {
   error?: boolean;
   getDisplayFromOption?: (option: any) => string;
   lookupAnnotationName: keyof MetadataStateBranch;
+  lookupTable?: string;
   onBlur?: () => void;
   onInputKeyDown?: (e: React.KeyboardEvent) => void;
   placeholder?: string;
@@ -200,7 +201,7 @@ class LookupSearch extends React.Component<Props, { searchValue?: string }> {
   };
 }
 
-const LARGE_LOOKUPS: readonly string[] = Object.freeze(["vial"]);
+const LARGE_LOOKUPS: readonly string[] = Object.freeze(["vial", "file"]);
 function mapStateToProps(
   state: State,
   {
@@ -209,6 +210,7 @@ function mapStateToProps(
     defaultOpen,
     disabled,
     lookupAnnotationName,
+    lookupTable,
     optionsOverride,
     optionsLoadingOverride,
     placeholder,
@@ -220,9 +222,7 @@ function mapStateToProps(
     clearOptionsOverride,
     defaultOpen,
     disabled,
-    isLargeLookup: LARGE_LOOKUPS.includes(
-      `${lookupAnnotationName}`.toLowerCase()
-    ),
+    isLargeLookup: LARGE_LOOKUPS.includes(`${lookupTable}`.toLowerCase()),
     lookupAnnotationName,
     options: optionsOverride || getMetadata(state)[lookupAnnotationName],
     optionsLoading:

--- a/src/renderer/containers/Table/DefaultCells/DefaultCell.tsx
+++ b/src/renderer/containers/Table/DefaultCells/DefaultCell.tsx
@@ -68,6 +68,7 @@ export default function DefaultCell(props: CellProps<FileModel, ColumnValue>) {
           <LookupEditor
             initialValue={value as string[]}
             lookupAnnotationName={column.id}
+            lookupTable={column?.lookupTable}
             commitChanges={commitChanges}
           />
         );

--- a/src/renderer/containers/Table/Editors/LookupEditor/index.tsx
+++ b/src/renderer/containers/Table/Editors/LookupEditor/index.tsx
@@ -9,12 +9,14 @@ const styles = require("../defaultInputStyles.pcss");
 interface Props {
   initialValue: string[];
   lookupAnnotationName: keyof MetadataStateBranch;
+  lookupTable?: string;
   commitChanges: (value: string[]) => void;
 }
 
 export default function LookupEditor({
   initialValue,
   lookupAnnotationName,
+  lookupTable,
   commitChanges,
 }: Props) {
   const [value, setValue] = useState<string[]>(initialValue);
@@ -31,6 +33,7 @@ export default function LookupEditor({
         onBlur={handleCommit}
         mode="multiple"
         lookupAnnotationName={lookupAnnotationName}
+        lookupTable={lookupTable}
         selectSearchValue={setValue}
         value={value}
       />

--- a/src/renderer/services/labkey-client/index.ts
+++ b/src/renderer/services/labkey-client/index.ts
@@ -36,8 +36,6 @@ import {
 const BASE_URL = "/labkey";
 const IN_SEPARATOR = "%3B";
 const FMS_FILE_TABLE_NAME = "file";
-const FMS_FILE_FILE_NAME = "Filename";
-const FMS_FILE_FILE_ID = "FileId";
 
 export default class LabkeyClient extends HttpCacheClient {
   public static createFilter(
@@ -179,12 +177,16 @@ export default class LabkeyClient extends HttpCacheClient {
     column: string,
     searchString = ""
   ): Promise<string[]> {
-    const additionalQueries = [`query.sort=${column}`, `query.maxRows=100`];
+    const additionalQueries = [
+      `query.columns=${column}`,
+      `query.sort=${column}`,
+      `query.maxRows=100`,
+    ];
     if (!isEmpty(searchString)) {
       // The fms.file table is so large that running "contains" queries on it will take forever, so use "eq" instead
       /*
        TODO:
-        In a more perfect world, annotations that reference other files (specifically files fitting certain annotation
+        In a more perfect world, annotations that reference other files (specifically, files fitting certain annotation
         filters) would involve a more complex UI where users would define how an FES (not LabKey) query would be shaped.
         e.g.
          For the one `fms.file` lookup annotation in use at time of writing, "Optical Control Id", the annotation
@@ -216,11 +218,7 @@ export default class LabkeyClient extends HttpCacheClient {
         `Could not find column named ${column} in ${schema}.${table}`
       );
     }
-    return rows.map((row: any) => {
-      return table === FMS_FILE_TABLE_NAME
-        ? `${row[FMS_FILE_FILE_NAME]} (${row[FMS_FILE_FILE_ID]})`
-        : row[properlyCasedKey];
-    });
+    return rows.map((row: any) => row[properlyCasedKey]);
   }
 
   /**
@@ -460,7 +458,7 @@ export default class LabkeyClient extends HttpCacheClient {
     return rows[0];
   }
 
-  // Returns LabKey query as an array of values
+  // Returns LabKey query as a an array of values
   public selectRowsAsList<T = any>(
     schema: string,
     table: string,

--- a/src/renderer/services/labkey-client/index.ts
+++ b/src/renderer/services/labkey-client/index.ts
@@ -36,6 +36,8 @@ import {
 const BASE_URL = "/labkey";
 const IN_SEPARATOR = "%3B";
 const FMS_FILE_TABLE_NAME = "file";
+const FMS_FILE_FILE_NAME = "Filename";
+const FMS_FILE_FILE_ID = "FileId";
 
 export default class LabkeyClient extends HttpCacheClient {
   public static createFilter(
@@ -177,16 +179,12 @@ export default class LabkeyClient extends HttpCacheClient {
     column: string,
     searchString = ""
   ): Promise<string[]> {
-    const additionalQueries = [
-      `query.columns=${column}`,
-      `query.sort=${column}`,
-      `query.maxRows=100`,
-    ];
+    const additionalQueries = [`query.sort=${column}`, `query.maxRows=100`];
     if (!isEmpty(searchString)) {
       // The fms.file table is so large that running "contains" queries on it will take forever, so use "eq" instead
       /*
        TODO:
-        In a more perfect world, annotations that reference other files (specifically, files fitting certain annotation
+        In a more perfect world, annotations that reference other files (specifically files fitting certain annotation
         filters) would involve a more complex UI where users would define how an FES (not LabKey) query would be shaped.
         e.g.
          For the one `fms.file` lookup annotation in use at time of writing, "Optical Control Id", the annotation
@@ -218,7 +216,11 @@ export default class LabkeyClient extends HttpCacheClient {
         `Could not find column named ${column} in ${schema}.${table}`
       );
     }
-    return rows.map((row: any) => row[properlyCasedKey]);
+    return rows.map((row: any) => {
+      return table === FMS_FILE_TABLE_NAME
+        ? `${row[FMS_FILE_FILE_NAME]} (${row[FMS_FILE_FILE_ID]})`
+        : row[properlyCasedKey];
+    });
   }
 
   /**
@@ -458,7 +460,7 @@ export default class LabkeyClient extends HttpCacheClient {
     return rows[0];
   }
 
-  // Returns LabKey query as a an array of values
+  // Returns LabKey query as an array of values
   public selectRowsAsList<T = any>(
     schema: string,
     table: string,

--- a/src/renderer/services/labkey-client/index.ts
+++ b/src/renderer/services/labkey-client/index.ts
@@ -35,6 +35,7 @@ import {
 
 const BASE_URL = "/labkey";
 const IN_SEPARATOR = "%3B";
+const FMS_FILE_TABLE_NAME = "file";
 
 export default class LabkeyClient extends HttpCacheClient {
   public static createFilter(
@@ -182,8 +183,20 @@ export default class LabkeyClient extends HttpCacheClient {
       `query.maxRows=100`,
     ];
     if (!isEmpty(searchString)) {
+      // The fms.file table is so large that running "contains" queries on it will take forever, so use "eq" instead
+      /*
+       TODO:
+        In a more perfect world, annotations that reference other files (specifically, files fitting certain annotation
+        filters) would involve a more complex UI where users would define how an FES (not LabKey) query would be shaped.
+        e.g.
+         For the one `fms.file` lookup annotation in use at time of writing, "Optical Control Id", the annotation
+         would be defined in a way such that the <LookupSearch> dropdown here in the Upload App would query only for
+         files with the annotation "IsOpticalControl" and with a value of "True".
+        - TF 2022-09-20
+       */
+      const filterMatchType = table === FMS_FILE_TABLE_NAME ? "eq" : "contains";
       additionalQueries.push(
-        `query.${column}~contains=${encodeURIComponent(searchString)}`
+        `query.${column}~${filterMatchType}=${encodeURIComponent(searchString)}`
       );
     }
     const lookupOptionsQuery = LabkeyClient.getSelectRowsURL(


### PR DESCRIPTION
**Context:**
[SWE-335](https://aicsjira.corp.alleninstitute.org/browse/SWE-335)
The "Optical Control ID" annotation dropdown in the File Upload App became difficult/impossible to use. The loading time after entering a FileID (at the input validation step) was either ridiculously long or never completed.

**Changes:**
* When querying for annotation values for annotations with the `Lookup` type, if the lookup is aimed at the `FMS.File` table, the query will use an "equals" filter instead of a "contains" filter. The "contains" filter is still valid for lookups on other, non-several-million-row-long tables
  * Left a TODO about how we could change this should more annotations be created that point at the `FMS.File` table
* `FMS.File` lookup annotation dropdowns no longer load the first 500 files in the table when the dropdown box is first clicked
* Some stuff got moved around by Prettier


**Testing:**
* Updated existing unit tests to pass with new `Lookup` type changes
* Manual testing
* Demo'd to one user

I'll also be making a set of tests for the `LabkeyClient` to help with changes related to SWE-279, which might capture some of the functionality present here

I originally planned to have this PR contain changes for both SWE-335 and SWE-279, but I've decided I'll make a separate PR for 279