### PR TITLE
remove dependence on FSS2 JSS stage

### DIFF
--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -8,7 +8,6 @@ import { extensionToFileTypeMap, FileType } from "../../util";
 import FileStorageService, {
   ChunkStatus,
   FSSUpload,
-  UploadStage,
   UploadStatus,
   UploadStatusResponse,
 } from "../file-storage-service";
@@ -454,13 +453,6 @@ export default class FileManagementSystem {
         await this.jss.updateJob(upload.jobId, {
           status: JSSJobStatus.RETRYING,
         });
-          // FSS may already have all the chunks it needs and is asynchronously
-          // comparing the MD5 hash
-          // TODO I am thinking this knowlege should be based on UploadStatus (does it equal POST_PROCESSING, or RETRY, or INACTIVE).
-        if (
-          fssUpload.currentStage === UploadStage.ADDING_CHUNKS ||
-          fssUpload.currentStage === UploadStage.WAITING_FOR_FIRST_CHUNK
-        ) {
           // If FSS is still available to continue receiving chunks of this upload
           // simply continue sending the chunks
           let lastChunkNumber = fssStatus.chunkStatuses.findIndex(
@@ -486,7 +478,6 @@ export default class FileManagementSystem {
             initialChunkNumber: lastChunkNumber,
             partiallyCalculatedMd5: upload.serviceFields.md5CalculationInformation?.[`${lastChunkNumber}`]
           });
-        }
       }
       //TODO handle case where UploadStatus == RETRY
     }

--- a/src/renderer/services/file-management-system/test/file-management-system.test.ts
+++ b/src/renderer/services/file-management-system/test/file-management-system.test.ts
@@ -13,7 +13,7 @@ import {
   MetadataManagementService,
 } from "../..";
 import { mockJob, mockWorkingUploadJob } from "../../../state/test/mocks";
-import { UploadStage, UploadStatus } from "../../file-storage-service";
+import { UploadStatus } from "../../file-storage-service";
 import {
   JSSJob,
   JSSJobStatus,
@@ -387,53 +387,48 @@ describe("FileManagementSystem", () => {
       expect(jss.createJob.getCalls()).to.be.lengthOf(2);
     });
 
-    [UploadStage.ADDING_CHUNKS, UploadStage.WAITING_FOR_FIRST_CHUNK].forEach(
-      (stage) => {
-        it(`resumes sending chunks for an upload with an active FSS status for stage ${stage}`, async () => {
-          // Arrange
-          const { mtime: fileLastModified } =
-          await fs.promises.stat(testFilePath);
-          const fileLastModifiedInMs = fileLastModified.getTime();
-          const upload: UploadJob = {
-            ...mockJob,
-            serviceFields: {
-              files: [
-                {
-                  file: {
-                    fileType: "text",
-                    originalPath: testFilePath,
-                  },
+      it(`resumes sending chunks for an upload with an WORKING FSS status`, async () => {
+        // Arrange
+        const { mtime: fileLastModified } =
+        await fs.promises.stat(testFilePath);
+        const fileLastModifiedInMs = fileLastModified.getTime();
+        const upload: UploadJob = {
+          ...mockJob,
+          serviceFields: {
+            files: [
+              {
+                file: {
+                  fileType: "text",
+                  originalPath: testFilePath,
                 },
-              ],
-              fssUploadId: "234124141",
-              fssUploadChunkSize: 13,
-              type: "upload",
-              lastModifiedInMS: fileLastModifiedInMs,
-              md5CalculationInformation:{
-                "0": "testPartialMd5"
-              }
-            },
-          };
-          const fssUpload: JSSJob = {
-            ...mockJob,
-            currentStage: stage,
-          };
-          jss.getJob.onFirstCall().resolves(upload);
-          fss.getStatus.resolves({
-            uploadStatus: UploadStatus.WORKING,
-            chunkStatuses: [],
-          });
-          jss.getJob.onSecondCall().resolves(fssUpload);
-
-          // Act
-          await fms.retry("mockUploadId", noop);
-
-          // Assert
-          expect(jss.createJob.called).to.be.false;
-          expect(fileReader.read).to.have.been.calledOnce;
+              },
+            ],
+            fssUploadId: "234124141",
+            fssUploadChunkSize: 13,
+            type: "upload",
+            lastModifiedInMS: fileLastModifiedInMs,
+            md5CalculationInformation:{
+              "0": "testPartialMd5"
+            }
+          },
+        };
+        const fssUpload: JSSJob = {
+          ...mockJob,
+        };
+        jss.getJob.onFirstCall().resolves(upload);
+        fss.getStatus.resolves({
+          uploadStatus: UploadStatus.WORKING,
+          chunkStatuses: [],
         });
-      }
-    );
+        jss.getJob.onSecondCall().resolves(fssUpload);
+
+        // Act
+        await fms.retry("mockUploadId", noop);
+
+        // Assert
+        expect(jss.createJob.called).to.be.false;
+        expect(fileReader.read).to.have.been.calledOnce;
+      });
 
     it("resumes an upload that just needs finalizing", async () => {
       // Arrange

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -36,11 +36,6 @@ export enum ChunkStatus {
   COMPLETE = "COMPLETE",
 }
 
-export enum UploadStage {
-  WAITING_FOR_FIRST_CHUNK = "WAITING_FOR_FIRST_CHUNK",
-  ADDING_CHUNKS = "ADDING_CHUNKS",
-}
-
 // RESPONSE TYPES
 interface RegisterUploadResponse {
   uploadId: string; // ID for tracking upload

--- a/src/renderer/services/job-status-service/types.ts
+++ b/src/renderer/services/job-status-service/types.ts
@@ -23,11 +23,6 @@ export interface UploadServiceFields {
   // Unique ID for tracking the upload according to FSS
   fssUploadId?: string;
 
-  // In the event an upload is resumed the chunk size requested by FSS
-  // initially may not still be around in which case it will be helpful
-  // to store it here to access as needed
-  fssUploadChunkSize?: number;
-
   // Identifies the upload as part of a larger group of uploads
   // useful for grouping uploads that were uploaded together
   groupId?: string;
@@ -186,6 +181,7 @@ export const FAILED_STATUSES = [
   JSSJobStatus.FAILED,
   JSSJobStatus.UNRECOVERABLE,
 ];
+//TODO why these are here
 export const IN_PROGRESS_STATUSES = [
   JSSJobStatus.BLOCKED,
   JSSJobStatus.RETRYING,

--- a/src/renderer/state/job/logics.ts
+++ b/src/renderer/state/job/logics.ts
@@ -193,14 +193,12 @@ const receiveFSSJobCompletionUpdateLogics = createLogic({
     const keyForRequest = `${AsyncRequest.COMPLETE_UPLOAD}-${fssUpload.jobId}-${fssUpload.status}`;
     const requestsInProgress = getRequestsInProgress(getState());
     const isDuplicateUpdate = requestsInProgress.includes(keyForRequest);
-    const isSuccessfulAndInLabKey =
+    const isFileIdInLabkey =
       fssUpload.status === JSSJobStatus.SUCCEEDED &&
-      fssUpload.serviceFields?.addedToLabkey?.status ===
-        JSSJobStatus.SUCCEEDED &&
       fssUpload.serviceFields?.fileId;
     if (
       !isDuplicateUpdate &&
-      (FAILED_STATUSES.includes(fssUpload.status) || isSuccessfulAndInLabKey)
+      (FAILED_STATUSES.includes(fssUpload.status) || isFileIdInLabkey)
     ) {
       next(action);
     } else {

--- a/src/renderer/state/job/test/logics.test.ts
+++ b/src/renderer/state/job/test/logics.test.ts
@@ -286,7 +286,6 @@ describe("Job logics", () => {
       ...mockSuccessfulUploadJob,
       jobId: fssUploadId,
       serviceFields: {
-        addedToLabkey: { status: JSSJobStatus.SUCCEEDED },
         fileId: "9203414",
       },
     };
@@ -351,34 +350,6 @@ describe("Job logics", () => {
         serviceFields: {
           ...successfulFSSUpload.serviceFields,
           fileId: undefined,
-        },
-      };
-
-      // Act
-      const action = receiveFSSJobCompletionUpdate(fssUpload);
-      store.dispatch(action);
-      await logicMiddleware.whenComplete();
-
-      // Assert
-      expect(actions.includesType(RECEIVE_FSS_JOB_COMPLETION_UPDATE)).to.be
-        .false;
-    });
-
-    it("rejects updates without labkey entries", async () => {
-      // Arrange
-      const { actions, logicMiddleware, store } = createMockReduxStore(
-        stateWithMatchingUpload,
-        undefined,
-        undefined,
-        false
-      );
-      const fssUpload = {
-        ...successfulFSSUpload,
-        serviceFields: {
-          ...successfulFSSUpload.serviceFields,
-          addedToLabkey: {
-            status: JSSJobStatus.FAILED,
-          },
         },
       };
 

--- a/src/renderer/state/test/mocks.ts
+++ b/src/renderer/state/test/mocks.ts
@@ -432,14 +432,6 @@ export const mockFSSUploadJob: FSSUpload = {
   service: Service.FILE_STORAGE_SERVICE,
   serviceFields: {
     fileId: "82beaf0460384911b6d6293fb333c4b0",
-    addedToLabkey: {
-      status: JSSJobStatus.SUCCEEDED,
-      statusDetail: "",
-    },
-    publishedToSns: {
-      status: JSSJobStatus.SUCCEEDED,
-      statusDetail: "",
-    },
   },
   status: JSSJobStatus.WORKING,
   user: "test_user",

--- a/src/renderer/state/test/mocks.ts
+++ b/src/renderer/state/test/mocks.ts
@@ -425,7 +425,7 @@ export const mockSuccessfulUploadJob: UploadJob = {
 
 export const mockFSSUploadJob: FSSUpload = {
   created: new Date(),
-  currentStage: "ADDING CHUNKS",
+  currentStage: "UPLOAD_IN_PROGRESS",
   jobId: "3333333333FSS",
   jobName: "mockFSSUploadJob",
   modified: new Date(),


### PR DESCRIPTION
# Purpose

Removes unnecessary updates to JSS stage; Info duplicates what is already communicated in `UploadStatus`, which is where clients should look for upload state updates.  This is a step toward removing JSS as a dependency of FSS2.

Piggyback on this, is a bugfix that was discovered.  An FSS2 API change was missed in a recent pr (`UploadStatusResponse.uploadStatus` -> `UploadStatusResponse.status`).  Additionally, some typing updates were needed and refactoring stemmed from that. 

# Changes

- Removed conditionals based on deprecated JSS stages.
- Removed dead code.
- Refactoring stemming from API changes

# Testing
Unit tests, manual testing (retrying a partially uploaded, failed upload).

# How to review
Refactoring stems from removal of deprecated file-storage-service.UploadStage values

**Related:** https://github.com/aics-int/file-storage-service/pull/187