### PR TITLE
[SWE-450] Fix issue where uploads can't be edited if they contain unexposed annotations

### DIFF
--- a/src/renderer/state/route/logics.ts
+++ b/src/renderer/state/route/logics.ts
@@ -35,8 +35,8 @@ import {
 } from "../feedback/actions";
 import { setPlateBarcodeToPlates } from "../metadata/actions";
 import {
+  getAllAnnotations,
   getAnnotationLookups,
-  getAnnotations,
   getBooleanAnnotationTypeId,
   getCurrentUploadFilePath,
   getImagingSessions,
@@ -190,7 +190,7 @@ function convertUploadRequestsToUploadStateBranch(
   files: UploadRequest[],
   state: State
 ): Upload {
-  const annotations = getAnnotations(state);
+  const annotations = getAllAnnotations(state);
   const lookups = getLookups(state);
   const annotationLookups = getAnnotationLookups(state);
   const annotationIdToAnnotationMap = groupBy(annotations, "annotationId");

--- a/src/renderer/state/route/test/logics.test.ts
+++ b/src/renderer/state/route/test/logics.test.ts
@@ -37,6 +37,7 @@ import {
   mockMMSTemplate,
   mockState,
   mockSuccessfulUploadJob,
+  mockSuccessfulUploadJobWithUnexposedAnnotation,
   mockWellAnnotation,
   mockWellUpload,
   nonEmptyStateForInitiatingUpload,
@@ -415,6 +416,21 @@ describe("Route logics", () => {
       );
 
       store.dispatch(viewUploads([mockFailedUploadJob]));
+      await logicMiddleware.whenComplete();
+
+      expect(actions.list.map(({ type }) => type)).includes(
+        VIEW_UPLOADS_SUCCEEDED
+      );
+    });
+    it("allows users to open an upload with unexposed annotations", async () => {
+      stubMethods({});
+      const { actions, logicMiddleware, store } = createMockReduxStore(
+        mockStateWithMetadata
+      );
+
+      store.dispatch(
+        viewUploads([mockSuccessfulUploadJobWithUnexposedAnnotation])
+      );
       await logicMiddleware.whenComplete();
 
       expect(actions.list.map(({ type }) => type)).includes(

--- a/src/renderer/state/test/mocks.ts
+++ b/src/renderer/state/test/mocks.ts
@@ -101,7 +101,7 @@ export const mockNotesAnnotation: Annotation = {
 
 const mockUnusableStructureAnnotation: Annotation = {
   ...mockAuditInfo,
-  annotationId: 3,
+  annotationId: 4,
   annotationTypeId: 1,
   description: "Other information",
   exposeToFileUploadApp: false,
@@ -416,6 +416,45 @@ export const mockSuccessfulUploadJob: JSSJob = {
         modified: new Date(),
       },
     },
+  },
+  status: JSSJobStatus.SUCCEEDED,
+  user: "test_user",
+};
+
+export const mockSuccessfulUploadJobWithUnexposedAnnotation: JSSJob = {
+  created: new Date(),
+  currentStage: "Completed",
+  jobId: "123434234",
+  jobName: "mockJob1",
+  modified: new Date(),
+  serviceFields: {
+    files: [
+      {
+        customMetadata: {
+          annotations: [
+            {
+              annotationId: 1,
+              values: ["test", "1"],
+            },
+            {
+              annotationId: 4,
+              values: ["test", "1"],
+            },
+          ],
+          templateId: 1,
+        },
+        file: {
+          originalPath: "/some/filepath",
+          fileType: "other",
+          shouldBeInArchive: true,
+          shouldBeInLocal: true,
+        },
+      },
+    ],
+    lastModified: {},
+    md5: {},
+    type: "upload",
+    uploadDirectory: "/foo",
   },
   status: JSSJobStatus.SUCCEEDED,
   user: "test_user",


### PR DESCRIPTION
#### Context
This PR address an error that was being thrown when users attempted to "view" a file with the "MXS Processing Failed" annotation. The logic for mapping out the annotation info for a given file was only looking for annotations to expose to the FUA. However, this became inappropriate with the addition of these new hidden annotations, and was already redundant given that the FUA later only displays the exposed annotations

#### Testing
I added one `logics` test to ensure that we can make it to the file viewing/editing page regardless of what annotations are attached to the file being viewed. It fails while using the main branch's code and succeeds after my changes.
I also manually tested one file I had available to me that had failed during MXS processing - I've confirmed that I can open and edit its metadata now