### PR TITLE
[SWE-550 & SWE-548] Prevent crashes on large chunk sizes and increase chunks in flight limit

### DIFF
--- a/src/renderer/services/file-management-system/ChunkedFileReader.ts
+++ b/src/renderer/services/file-management-system/ChunkedFileReader.ts
@@ -5,6 +5,8 @@ import BatchedTaskQueue from "../../entities/BatchedTaskQueue";
 
 import Md5Hasher from "./Md5Hasher";
 
+const READ_STREAM_MAX_CHUNK_SIZE = 100 * 1000 * 1000; // 100 MB
+
 // Create an explicit error class to capture cancellations
 export class CancellationError extends Error {
   constructor() {
@@ -55,12 +57,13 @@ export default class ChunkedFileReader {
     partiallyCalculatedMd5?: string
   }): Promise<string> {
     const { uploadId, source, onProgress, chunkSize, offset, partiallyCalculatedMd5 } = config;
+    const readStreamChunkSize = Math.min(chunkSize, READ_STREAM_MAX_CHUNK_SIZE);
     const readStream = fs.createReadStream(source, {
       // Offset the start byte by the offset param
       start: offset,
       // Control the MAX amount of bytes we read at a time
       // not necessarily guaranteed
-      highWaterMark: chunkSize,
+      highWaterMark: readStreamChunkSize,
     });
 
     let hasher = new Md5Hasher();

--- a/src/renderer/services/file-management-system/ChunkedFileReader.ts
+++ b/src/renderer/services/file-management-system/ChunkedFileReader.ts
@@ -5,7 +5,15 @@ import BatchedTaskQueue from "../../entities/BatchedTaskQueue";
 
 import Md5Hasher from "./Md5Hasher";
 
-const READ_STREAM_MAX_CHUNK_SIZE = 100 * 1000 * 1000; // 100 MB
+/* Limit the read stream to 100 MB chunks. This is required because with 300MB chunks the read
+ * stream allocates enough memory to hit Electron's maximum heap usage and crash the app.
+ * 100MB is big enough because our maximum chunk size for an upload should be 500MB, because S3
+ * supports files up to 5TB with up to 10,000 chunks, and 100MB here means at most five reads per
+ * chunk, which doesn't seem like much overhead.
+ * 100MB is small enough because on Philp's Macbook the app did not crash at 200MB; this gives us a
+ * 2x safety factor. Electron's maximum heap size should be consistent across machines.
+ */
+const READ_STREAM_MAX_CHUNK_SIZE = 100 * 1000 * 1000;
 
 // Create an explicit error class to capture cancellations
 export class CancellationError extends Error {


### PR DESCRIPTION
## Context
There are two changes happening here, but I want them in one PR because the first one (SWE-550, to fix the crash on large chunk sizes) seems to degrade performance without the second one (increasing chunks in flight limit).

## SWE-550: Large chunk crash
### The issue
When a user uploads a large file via FUA to FSS2, we run into S3's limit on chunks per object of 10,000. This means that, e.g., for a 3TB file the chunk size for uploads to FSS2 is set to 3TB/10000 = 300MB.

To simulate this condition (I don't have 3TB of hard drive space), I try to upload a 10GB file with a chunk size of 300MB using the following patch (applied to main-FSS2):

```
--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -149,12 +149,13 @@ export default class FileManagementSystem {
         },
       });
 
+      const FORCED_CHUNK_SIZE = 300 * 1000 * 1000; // 300 MB
       // Wait for upload
       await this.uploadInChunks({
         uploadId: upload.jobId,
         fssUploadId: registration.uploadId,
         source: source,
-        chunkSize: registration.chunkSize,
+        chunkSize: FORCED_CHUNK_SIZE,
         user: upload.user,
         onProgress: (bytesUploaded) => onProgress({ bytesUploaded, totalBytes: fileSize })
       });
```
With this simulation of a 3TB upload, FUA crashes when the upload starts with an error about running into the maximum heap size limit. (Because the crash is related to heap usage, I strongly suspect that we would have the same problem with a real 3TB upload.)

### The fix
The crash happens when trying to initialize a `readStream` with a large chunk size (the problem wasn't really with our code!). So, I put a limit on the number of bytes the `readStream` can get at once. 100MB is I think high enough that we don't have substantial overhead from calling our `transform` function many times (if we get the full 100MB, it's a maximum 5 reads from the stream to get to our maximum chunk size 500MB).

## SWE-548: FUA performance
The previous best performance of FUA against FSS2 was around 12-17 MBps. The latest `main-FSS2` (v2.8.1-snapshot.29) however only uploads at about 6 MBps. Relaxing the limit on chunks in flight gets us back to our previous best for FSS2, at about 16 MBps. However, this is still far from the 35 MBps we see against the old FSS.

## Testing
* I uploaded a 10GB file (10GB-test-philip-13) with the changes from this branch (831ee414) to staging. It achieved 16 MBps.
* For SWE-550: From this branch, I applied a patch like the one shown above to set the chunk size to 500MB (the maximum we should ever have, for a 5TB file). You can view that code at the SWE-550-test branch (commit 8beacb). I uploaded a 10GB file (10GB-test-philip-13) to staging and confirmed that it did send 500MB chunks. It uploaded at 16 MBps.