### PR TITLE
updating tooltip for FSS2 workflow

### DIFF
--- a/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
@@ -24,13 +24,11 @@ const POWER_OF_1000_TO_ABBREV = new Map<number, string>([
 enum Step {
   ONE,
   TWO,
-  THREE,
 }
 
 const STEP_INFO = {
-  [Step.ONE]: "Step 1 of 3: Reading file",
-  [Step.TWO]: "Step 2 of 3: Uploading file",
-  [Step.THREE]: "Step 3 of 3: Adding metadata",
+  [Step.ONE]: "Step 1 of 2: Uploading file",
+  [Step.TWO]: "Step 2 of 2: Adding metadata",
 };
 
 function getBytesDisplay(bytes: number): string {
@@ -88,33 +86,21 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
     );
   } else {
     const {
-      md5BytesComputed = 0,
       bytesUploaded = 0,
       totalBytes = 0,
     } = props.row.original.progress || {};
 
     let step = Step.ONE;
-    let bytesCompletedForStep = md5BytesComputed;
-    let displayForStep = getBytesDisplay(bytesCompletedForStep);
+    let displayForStep = getBytesDisplay(bytesUploaded);
     let totalForStep = getBytesDisplay(totalBytes);
+    let progressForStep = 0;
     // If all bytes have been uploaded then the upload is on the last step
-    if (bytesUploaded >= totalBytes) {
-      step = Step.THREE;
-      bytesCompletedForStep = 0;
+    if (totalBytes > 0 && bytesUploaded >= totalBytes) {
+      step = Step.TWO;
       displayForStep = "0";
       totalForStep = "1";
-    } else if (bytesUploaded || md5BytesComputed === totalBytes) {
-      // If any bytes are uploaded or if step 1 has completed then the upload
-      // is on the second step
-      step = Step.TWO;
-      bytesCompletedForStep = bytesUploaded;
-      displayForStep = getBytesDisplay(bytesCompletedForStep);
-      totalForStep = getBytesDisplay(totalBytes);
-    }
-
-    let progressForStep = 0;
-    if (bytesCompletedForStep && totalBytes) {
-      progressForStep = Math.floor((bytesCompletedForStep / totalBytes) * 100);
+    } else if (bytesUploaded && totalBytes) {
+      progressForStep = Math.floor((bytesUploaded / totalBytes) * 100);
     }
 
     tooltip = `${tooltip} - ${STEP_INFO[step]}`;
@@ -127,7 +113,7 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
           status="active"
         />
         <div className={styles.activeInfo}>
-          <p>Step {step + 1} of 3</p>
+          <p>Step {step + 1} of 2</p>
           <p>
             {displayForStep} / {totalForStep}
           </p>

--- a/src/renderer/containers/Table/CustomCells/StatusCell/test/StatusCell.test.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/test/StatusCell.test.tsx
@@ -68,7 +68,7 @@ describe("<StatusCell />", () => {
     const row = {
       original: {
         progress: {
-          md5BytesComputed: 4245,
+          bytesUploaded: 4245,
           totalBytes: 82341,
         },
       },
@@ -81,17 +81,17 @@ describe("<StatusCell />", () => {
 
     // Assert
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
-      "WORKING - Step 1 of 3: Reading file"
+      "WORKING - Step 1 of 2: Uploading file"
     );
     expect(wrapper.find(Progress).prop("percent")).to.equal(5);
   });
 
-  it("shows step 2 when md5 calc complete", () => {
+  it("shows step 2 when no bytes uploaded", () => {
     // Arrange
     const row = {
       original: {
         progress: {
-          md5BytesComputed: 82341,
+          bytesUploaded: 0,
           totalBytes: 82341,
         },
       },
@@ -104,7 +104,7 @@ describe("<StatusCell />", () => {
 
     // Assert
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
-      "WORKING - Step 2 of 3: Uploading file"
+      "WORKING - Step 1 of 2: Uploading file"
     );
     expect(wrapper.find(Progress).prop("percent")).to.equal(0);
   });
@@ -127,7 +127,7 @@ describe("<StatusCell />", () => {
 
     // Assert
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
-      "WORKING - Step 2 of 3: Uploading file"
+      "WORKING - Step 1 of 2: Uploading file"
     );
     expect(wrapper.find(Progress).prop("percent")).to.equal(60);
   });
@@ -150,7 +150,7 @@ describe("<StatusCell />", () => {
 
     // Assert
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
-      "WORKING - Step 3 of 3: Adding metadata"
+      "WORKING - Step 2 of 2: Adding metadata"
     );
     expect(wrapper.find(Progress).prop("percent")).to.equal(0);
   });

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -488,6 +488,9 @@ export default class FileManagementSystem {
   }): Promise<void> {
     const { uploadId, fssUploadId, source, chunkSize, user, onProgress, initialChunkNumber = 0, partiallyCalculatedMd5 } = config;
     let chunkNumber = initialChunkNumber;
+    
+    //Initialize bytes uploaded with progress made previously
+    onProgress(chunkSize * initialChunkNumber);
 
     // Throttle the progress callback to avoid sending
     // too many updates on fast uploads


### PR DESCRIPTION
**Objective:**

This pr updates the tooltip text, status and progress to report on the FSS2 workflow, which consists of only 2 steps (`upload file [includes md5 compute]`, `adding metadata`) vs the FSS current workflow, which consists of 3 steps (`pre-computing MD5`, `upload file`, `adding metadata`).

**Testing:**

Unit tests, manual testing