### PR TITLE
Feature/swe 490 retry policy

### DIFF
--- a/src/renderer/containers/App/index.tsx
+++ b/src/renderer/containers/App/index.tsx
@@ -11,7 +11,7 @@ import {
   RendererProcessEvents,
 } from "../../../shared/constants";
 import StatusBar from "../../components/StatusBar";
-import { FSSUpload } from "../../services/file-storage-service";
+import { FSSUpload, UploadStatus } from "../../services/file-storage-service";
 import {
   JSSJob,
   JSSJobStatus,
@@ -112,10 +112,11 @@ export default function App() {
     eventSource.addEventListener("jobUpdate", (event: MessageEvent) => {
       const job = camelizeKeys(JSON.parse(event.data) as object) as JSSJob;
       // An FSS job update is only important to us when it is signaling
-      // the addition of the fileId i.e. FSS's completion or has failed
+      // the addition of the fileId i.e. FSS's completion, has failed,
+      // or requires this clients intervention to retry
       if (
         job.service === Service.FILE_STORAGE_SERVICE &&
-        (job.serviceFields?.fileId || job.status === JSSJobStatus.FAILED)
+        (job.serviceFields?.fileId || job.status === JSSJobStatus.FAILED || job.currentStage === UploadStatus.RETRY)
       ) {
         dispatch(receiveFSSJobCompletionUpdate(job as FSSUpload));
       } else if (job.serviceFields?.type === "upload") {

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -141,6 +141,17 @@ export default class FileStorageService extends HttpCacheClient {
   }
 
   /**
+   * This is a retry of the final step of the upload, this might be necessary in cases where something goes awry on the server's
+   * side during this step of the upload.
+   * The MD5 is included, and will be used by the server for a checksum.
+   * Other post upload tasks may also occur.
+   */
+  public retryFinalize(uploadId: string, md5: string): Promise<UploadChunkResponse> {
+    const url = `${FileStorageService.BASE_UPLOAD_PATH}/${uploadId}/retry?md5=${md5}`;
+    return this.patch<UploadChunkResponse>(url, undefined);
+  }
+
+  /**
    * This cancels the upload if it exists and can be canceled from the
    * service's perspective.
    */

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -141,8 +141,8 @@ export default class FileStorageService extends HttpCacheClient {
   }
 
   /**
-   * This is a retry of the final step of the upload, this might be necessary in cases where something goes awry on the server's
-   * side during this step of the upload.
+   * This is a retry of the final asynchronous step of the upload, this might be necessary in cases where something goes awry
+   * on the server's side during this step of the upload.
    * The MD5 is included, and will be used by the server for a checksum.
    * Other post upload tasks may also occur.
    */

--- a/src/renderer/state/job/logics.ts
+++ b/src/renderer/state/job/logics.ts
@@ -111,7 +111,6 @@ const receiveJobUpdateLogics = createLogic({
       isUploadSuccessfulAndComplete(updatedJob) &&
       !isUploadSuccessfulAndComplete(previousJob)
     ) {
-      // TODO: Need to do a check to see if updates include an fss status of RETRY (which is shown to be the stage of the jss job)
       dispatch(uploadSucceeded(jobName));
     } else if (
       previousJob &&

--- a/src/renderer/state/job/logics.ts
+++ b/src/renderer/state/job/logics.ts
@@ -1,6 +1,7 @@
 import { createLogic } from "redux-logic";
 
 import { UploadProgressInfo } from "../../services/file-management-system";
+import { UploadStatus } from "../../services/file-storage-service";
 import {
   FAILED_STATUSES,
   IN_PROGRESS_STATUSES,
@@ -172,6 +173,26 @@ const receiveFSSJobCompletionUpdateLogics = createLogic({
         matchingUploadJob.status !== JSSJobStatus.FAILED
       ) {
         await fms.failUpload(matchingUploadJob.jobId, "FSS upload failed");
+      } else if (
+        fssUpload.currentStage === UploadStatus.RETRY &&
+        matchingUploadJob.status !== JSSJobStatus.RETRYING
+      ) {
+        try {
+          const info = `Checking to see if "${matchingUploadJob.jobName}" can be resumed after server failure.`;
+          dispatch(setInfoAlert(info));
+
+          const onProgress = (
+            uploadId: string,
+            progress: UploadProgressInfo
+          ) => {
+            dispatch(updateUploadProgressInfo(uploadId, progress));
+          };
+          await fms.retry(matchingUploadJob.jobId, onProgress);
+        } catch (e) {
+          const message = `Retry for upload "${matchingUploadJob.jobName}" failed: ${e.message}`;
+          console.error(message, e);
+          dispatch(setErrorAlert(message));
+        }
       }
     }
 
@@ -197,9 +218,10 @@ const receiveFSSJobCompletionUpdateLogics = createLogic({
     const isFileIdInLabkey =
       fssUpload.status === JSSJobStatus.SUCCEEDED &&
       fssUpload.serviceFields?.fileId;
+    const requiresRetry = fssUpload.currentStage === UploadStatus.RETRY;
     if (
       !isDuplicateUpdate &&
-      (FAILED_STATUSES.includes(fssUpload.status) || isFileIdInLabkey)
+      (FAILED_STATUSES.includes(fssUpload.status) || isFileIdInLabkey || requiresRetry)
     ) {
       next(action);
     } else {

--- a/src/renderer/state/job/logics.ts
+++ b/src/renderer/state/job/logics.ts
@@ -110,6 +110,7 @@ const receiveJobUpdateLogics = createLogic({
       isUploadSuccessfulAndComplete(updatedJob) &&
       !isUploadSuccessfulAndComplete(previousJob)
     ) {
+      // TODO: Need to do a check to see if updates include an fss status of RETRY (which is shown to be the stage of the jss job)
       dispatch(uploadSucceeded(jobName));
     } else if (
       previousJob &&

--- a/src/renderer/state/job/test/logics.test.ts
+++ b/src/renderer/state/job/test/logics.test.ts
@@ -411,7 +411,7 @@ describe("Job logics", () => {
       await logicMiddleware.whenComplete();
 
       // Assert
-        expect(actions.includesType(SET_ALERT)).to.be.true;
+      expect(actions.includesType(SET_ALERT)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
This sets up the FUA to retry the final server-side portion of the upload when told by the JSS job FSS creates that the server is waiting to be retried.

**Testing**
Tested by modifying the JSS job manually to show as though it were in a retry state and seeing what the app did along with unit testing.