### PR TITLE
[SWE-496] delete md5 calc info at end of upload

### DIFF
--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -183,6 +183,9 @@ export default class FileManagementSystem {
         {
           status: JSSJobStatus.SUCCEEDED,
           serviceFields: {
+            // Clear the MD5 progress information now that the upload is complete
+            // to reduce the space this job takes up in the DB & in memory later on
+            md5CalculationInformation: {},
             result: [
               {
                 fileId,


### PR DESCRIPTION
Converts the MD5 calculation information object back into an empty object at the end of the upload.

**Testing**
Uploaded a file and check the JSS job during and at the end of it.