### PR TITLE
[SWE-581] Reset upload once confirmed

### DIFF
--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -220,7 +220,10 @@ const initiateUploadLogic = createLogic({
       return;
     }
 
-    dispatch(initiateUploadSucceeded(action.payload));
+    dispatch(batchActions([
+      initiateUploadSucceeded(action.payload),
+      resetUpload()
+    ]))
 
     const uploadTasks = uploads.map((upload) => async () => {
       try {

--- a/src/renderer/state/upload/test/logics.test.ts
+++ b/src/renderer/state/upload/test/logics.test.ts
@@ -26,6 +26,7 @@ import { getAlert } from "../../feedback/selectors";
 import { setPlateBarcodeToPlates } from "../../metadata/actions";
 import { SET_PLATE_BARCODE_TO_PLATES } from "../../metadata/constants";
 import { getPlateBarcodeToPlates } from "../../metadata/selectors";
+import { resetUpload } from "../../route/actions";
 import { setAppliedTemplate } from "../../template/actions";
 import {
   createMockReduxStore,
@@ -320,6 +321,30 @@ describe("Upload logics", () => {
         )
       ).to.be.true;
     });
+
+    it("resets upload state after initiate is complete", async () => {
+      // Arrange
+      fms.initiateUpload.resolves(initiatedUpload);
+      jssClient.existsById.resolves(true);
+      const errorMessage = "uploadFile failed";
+      fms.upload.rejects(new Error(errorMessage));
+      const { actions, logicMiddleware, store } = createMockReduxStore(
+        nonEmptyStateForInitiatingUpload,
+        mockReduxLogicDeps,
+        uploadLogics
+      );
+
+      // Act
+      store.dispatch(initiateUpload());
+      await logicMiddleware.whenComplete();
+
+      // Assert
+      expect(
+        actions.includesMatch(
+          resetUpload()
+        )
+      ).to.be.true;
+    })
   });
   describe("retryUploadsLogic", () => {
     it("calls fms.retry if no missing info on job", async () => {


### PR DESCRIPTION
Upload data was not being cleared from the state after the upload was initiated and the user was moved to the "My Uploads" page. This led to some confusing behavior where to do another upload the user had to click on "Current Upload" and click the "Clear" button discarding the upload data themselves then coming back and starting a new upload from the "My Uploads" page again.