### PR TITLE
[SWE-387] Move partial md5 into fss

### DIFF
--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -462,7 +462,7 @@ export default class FileManagementSystem {
             throw new Error('No partial MD5 for chunk ' + lastChunkNumber);
           }
           const md5 = Md5Hasher.deserialize(partiallyCalculatedMd5).digest();
-          await this.fss.retryFinalize(fssUploadId, md5)
+          await this.fss.finalize(fssUploadId, md5)
         } else if (fssStatus.status === UploadStatus.WORKING) {
           const { originalPath } = upload.serviceFields.files[0].file;
           const { size: fileSize } = await fs.promises.stat(originalPath);

--- a/src/renderer/services/file-management-system/test/file-management-system.test.ts
+++ b/src/renderer/services/file-management-system/test/file-management-system.test.ts
@@ -156,6 +156,7 @@ describe("FileManagementSystem", () => {
         }
         inFlightFssRequests--;
         return {
+          errorCount: 0,
           chunkNumber: 0,
           uploadId: 'testID',
         };
@@ -267,7 +268,7 @@ describe("FileManagementSystem", () => {
       fss.fileExistsByNameAndSize.resolves(false);
       fss.registerUpload.resolves({ status: UploadStatus.WORKING, chunkStatuses: [], uploadId: "091234124", chunkSize: 2424 });
       fss.finalize.resolves({
-        fileId,
+        errorCount: 0,
         chunkNumber: 14,
         uploadId: upload.jobId,
       });
@@ -317,7 +318,7 @@ describe("FileManagementSystem", () => {
       fss.fileExistsByNameAndSize.resolves(false);
       fss.registerUpload.resolves({ status: UploadStatus.WORKING, chunkStatuses: [], uploadId: "091234124", chunkSize: 2424 });
       fss.finalize.resolves({
-        fileId,
+        errorCount: 0,
         chunkNumber: 14,
         uploadId: upload.jobId,
       });
@@ -366,7 +367,7 @@ describe("FileManagementSystem", () => {
       fss.fileExistsByNameAndSize.resolves(false);
       fss.registerUpload.resolves({ status: UploadStatus.WORKING, chunkStatuses: [], uploadId: "091234124", chunkSize: 2424 });
       fss.finalize.resolves({
-        fileId,
+        errorCount: 0,
         chunkNumber: 14,
         uploadId: upload.jobId,
       });
@@ -405,14 +406,12 @@ describe("FileManagementSystem", () => {
             fssUploadId: "234124141",
             type: "upload",
             lastModifiedInMS: fileLastModifiedInMs,
-            md5CalculationInformation:{
-              "0": "testPartialMd5"
-            }
           },
         };
         const fssUpload: JSSJob = {
           ...mockJob,
         };
+        fss.getChunkInfo.resolves({cumulativeMD5: "anyMd5", size: 0, status: UploadStatus.COMPLETE})
         jss.getJob.onFirstCall().resolves(upload);
         fss.getStatus.resolves({
           status: UploadStatus.WORKING,
@@ -449,9 +448,6 @@ describe("FileManagementSystem", () => {
           fssUploadId: "234124141",
           type: "upload",
           lastModifiedInMS: fileLastModifiedInMs,
-          md5CalculationInformation:{
-            "0": "testPartialMd5"
-          }
         },
       };
       const fssUploadJob: FSSUpload = {
@@ -470,7 +466,7 @@ describe("FileManagementSystem", () => {
         chunkStatuses: [],
       });
       fss.finalize.resolves({
-        fileId,
+        errorCount: 0,
         chunkNumber: 14,
         uploadId: fuaUploadJob.jobId,
       });

--- a/src/renderer/services/file-storage-service/test/file-storage-service.test.ts
+++ b/src/renderer/services/file-storage-service/test/file-storage-service.test.ts
@@ -83,6 +83,7 @@ describe("FileStorageService", () => {
         uploadId,
         chunkNumber,
         rangeStart,
+        "anyMd5",
         postBody,
         "testUser"
       );

--- a/src/renderer/services/job-status-service/types.ts
+++ b/src/renderer/services/job-status-service/types.ts
@@ -27,12 +27,6 @@ export interface UploadServiceFields {
   // useful for grouping uploads that were uploaded together
   groupId?: string;
 
-  md5CalculationInformation?: {
-    // To ensure the MD5 calculation resumes at the same chunk
-    // as next time, save the chunkNumber relative to the partial MD5 calculation
-    [chunkNumber: string]: string
-  }
-
   // Tracks the modified date present in the upload file's metadata at the time
   // the MD5 calculation began. If this date is different than the current
   // upload file's metadata it can be concluded that the MD5 may no longer

--- a/src/renderer/state/job/test/selectors.test.ts
+++ b/src/renderer/state/job/test/selectors.test.ts
@@ -84,7 +84,6 @@ describe("Job selectors", () => {
         serviceFields: {
           files: [],
           lastModifiedInMS: new Date().getMilliseconds(),
-          md5CalculationInformation: {},
           originalJobId: mockReplacedJob2.jobId,
           type: "upload",
         },

--- a/src/renderer/state/test/mocks.ts
+++ b/src/renderer/state/test/mocks.ts
@@ -447,7 +447,6 @@ export const mockWorkingUploadJob: UploadJob = {
   serviceFields: {
     files: [],
     lastModifiedInMS: new Date().getMilliseconds(),
-    md5CalculationInformation: {},
     type: "upload",
   },
   status: JSSJobStatus.WORKING,
@@ -488,7 +487,6 @@ export const mockFailedUploadJob: UploadJob = {
       },
     ],
     lastModifiedInMS: new Date().getMilliseconds(),
-    md5CalculationInformation: {},
     type: "upload",
   },
   status: JSSJobStatus.FAILED,


### PR DESCRIPTION
This moves the partial MD5 persistence necessary to be able to resume an upload at any chunk from JSS to FSS which reduces the HTTP requests we have to make and moves chunk information into one place.

**Testing**
Started, stopped, and resumed uploads against staging