### PR TITLE
[SWE-376] Remove CSC envs for Windows release in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,3 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # Windows certs
-          CSC_LINK: ${{secrets.CSC_LINK}}
-          CSC_KEY_PASSWORD: ${{secrets.CSC_KEY_PASSWORD}}


### PR DESCRIPTION
This _should_ remove the code-signing step in the Windows build process, if I understand correctly