### PR TITLE
[UR-93] Highlight annotations that trigger post-processing

### DIFF
--- a/src/renderer/containers/TemplateEditorModal/index.tsx
+++ b/src/renderer/containers/TemplateEditorModal/index.tsx
@@ -28,7 +28,7 @@ import {
   getTemplateEditorVisible,
 } from "../../state/feedback/selectors";
 import { getAnnotationsWithAnnotationOptions } from "../../state/metadata/selectors";
-import { getShowTemplateHint } from "../../state/setting/selectors";
+import { getShowTemplateHint, getShowAddAnnotationHint } from "../../state/setting/selectors";
 import {
   addExistingAnnotation,
   addExistingTemplate,
@@ -54,6 +54,9 @@ const styles = require("./styles.pcss");
 
 const { Search } = Input;
 
+const ADD_ANNOTATION_DESCRIPTION = `Certain annotations trigger automated processes for new uploads.
+Optical Control ID and Is Optical Control are used to submit images for automatic alignment.
+Well is used to automatically add metadata from Labkey.`
 const COLUMN_TEMPLATE_DESCRIPTION = `A ${SCHEMA_SYNONYM} defines a group of annotations to associate with files.
 When applied to a batch of files to upload, the annotations associated with that template
 will be added as additional columns to fill out for each file. They can be shared and discovered by anyone.`;
@@ -108,6 +111,7 @@ function TemplateEditorModal(props: Props) {
   const dispatch = useDispatch();
   const template = useSelector(getTemplateDraft);
   const originalTemplate = useSelector(getOriginalTemplate);
+  const showAnnotationHint = useSelector(getShowAddAnnotationHint);
   const showTemplateHint = useSelector(getShowTemplateHint);
   const allAnnotations = useSelector(getAnnotationsWithAnnotationOptions);
   const requestsInProgress = useSelector(
@@ -426,6 +430,15 @@ function TemplateEditorModal(props: Props) {
               <Popover content={annotationOptionList} placement="right">
                 <Button icon={<PlusOutlined />} className={styles.addAnnotationButton} />
               </Popover>
+              {showAnnotationHint && (
+                <Alert
+                  className={styles.alert}
+                  closable={true}
+                  showIcon={true}
+                  type="info"
+                  message={ADD_ANNOTATION_DESCRIPTION}
+                />
+              )}
             </div>
             <div className={styles.annotationContainer}>
               <Table

--- a/src/renderer/containers/TemplateEditorModal/styles.pcss
+++ b/src/renderer/containers/TemplateEditorModal/styles.pcss
@@ -14,8 +14,9 @@
 
 .add-annotation-button {
     border-radius: 20px;
-    margin-left: 0.5em;
-    padding-top: 2px;
+    flex-basis: 30px;
+    flex-shrink: 0; /* Minimum width is flex-basis */
+    margin-bottom: 0.5em;
 }
 
 .annotation-label {
@@ -48,6 +49,12 @@
 
 .annotation-list-header {
     display: flex;
+    align-items: flex-end;
+    gap: 0.5em;
+}
+
+.annotation-list-header > .alert {
+    margin-bottom: 0.5em;
 }
 
 .annotation-list-header > h4 {

--- a/src/renderer/state/setting/reducer.ts
+++ b/src/renderer/state/setting/reducer.ts
@@ -18,6 +18,7 @@ export const initialState: SettingStateBranch = {
   limsPort: LIMS_PORT,
   limsProtocol: LIMS_PROTOCOL,
   metadataColumns: [],
+  showAddAnnotationHint: true,
   showUploadHint: true,
   showTemplateHint: true,
   username: userInfo().username,

--- a/src/renderer/state/setting/selectors.ts
+++ b/src/renderer/state/setting/selectors.ts
@@ -6,6 +6,7 @@ export const getLimsHost = (state: State) => state.setting.limsHost;
 export const getLimsPort = (state: State) => state.setting.limsPort;
 export const getLimsProtocol = (state: State) => state.setting.limsProtocol;
 export const getShowUploadHint = (state: State) => state.setting.showUploadHint;
+export const getShowAddAnnotationHint = (state: State) => state.setting.showAddAnnotationHint;
 export const getShowTemplateHint = (state: State) =>
   state.setting.showTemplateHint;
 export const getLoggedInUser = (state: State) => state.setting.username;
@@ -14,10 +15,11 @@ export const getEnabledNotifications = (state: State) =>
   state.setting.enabledNotifications;
 
 export const getEditableSettings = createSelector(
-  [getEnabledNotifications, getShowUploadHint, getShowTemplateHint],
-  (enabledNotifications, showUploadHint, showTemplateHint) => {
+  [getEnabledNotifications, getShowAddAnnotationHint, getShowUploadHint, getShowTemplateHint],
+  (enabledNotifications, showAddAnnotationHint, showUploadHint, showTemplateHint) => {
     return {
       enabledNotifications,
+      showAddAnnotationHint,
       showUploadHint,
       showTemplateHint,
     };

--- a/src/renderer/state/setting/test/logics.test.ts
+++ b/src/renderer/state/setting/test/logics.test.ts
@@ -27,6 +27,7 @@ import {
 import { updateSettingsLogic } from "../logics";
 import {
   getLimsHost,
+  getShowAddAnnotationHint,
   getShowTemplateHint,
   getShowUploadHint,
   getTemplateId,
@@ -82,6 +83,21 @@ describe("Setting logics", () => {
       store.dispatch(updateSettings({ templateId: 3 }));
 
       expect(getTemplateId(store.getState())).to.equal(3);
+    });
+
+    it("sets whether to show the template hint in settings", () => {
+      const { store } = createMockReduxStore({
+        ...mockState,
+        setting: {
+          ...mockState.setting,
+        },
+      });
+
+      expect(getShowTemplateHint(store.getState())).to.be.true;
+
+      store.dispatch(updateSettings({ showTemplateHint: false }));
+
+      expect(getShowTemplateHint(store.getState())).to.be.false;
     });
 
     it("sets whether to show the upload hint in settings", () => {

--- a/src/renderer/state/types.ts
+++ b/src/renderer/state/types.ts
@@ -287,6 +287,7 @@ export interface EnabledNotifications {
 
 export interface SettingStateBranch extends LimsUrl {
   metadataColumns: string[];
+  showAddAnnotationHint: boolean;
   // if true show hints on how to use the grid to enter data
   showUploadHint: boolean;
   showTemplateHint: boolean;


### PR DESCRIPTION
Make users more aware of `Is Optical Control`, `Optical Control ID`, and `Well` when creating a new template. The alert added here is brief because each annotation has a longer description that is shown both when creating a template and (in a tooltip) when doing an upload with a metadata template.

### Testing
Manual & `yarn test`.
![Screenshot 2023-03-06 at 3 57 57 PM](https://user-images.githubusercontent.com/5379348/223541796-7141b5a0-0afe-4865-8f58-0d2d9b3234d4.png)
![Screenshot 2023-03-06 at 3 58 15 PM](https://user-images.githubusercontent.com/5379348/223541806-4e93e919-cd3d-4cca-a032-147759651d6c.png)
