### PR TITLE
status/progress updates from JSS sse

### DIFF
--- a/src/renderer/containers/App/index.tsx
+++ b/src/renderer/containers/App/index.tsx
@@ -64,11 +64,11 @@ message.config({
 });
 
 export function handleUploadJobUpdates(job: JSSJob, dispatch: Dispatch<any>){
-      // An FSS job update happens when:
-      //   * fileId has been published
-      //   * progress has been published on a pre-upload md5, file upload, or post-upload md5
-      //   * requires this clients intervention to retry
       if (job.service === Service.FILE_STORAGE_SERVICE) {
+        // An FSS job update happens when:
+        //   * fileId has been published
+        //   * progress has been published on a pre-upload md5, file upload, or post-upload md5
+        //   * requires this clients intervention to retry
         const fssJob = job as FSSUpload;
         const totalBytes = fssJob.serviceFields.fileSize || 0; // 0 is a safe default, but in practice filesize is initialized immediately after job creation.
         if (fssJob.serviceFields?.fileId || fssJob.currentStage === UploadStatus.INACTIVE || fssJob.currentStage === UploadStatus.RETRY) {

--- a/src/renderer/containers/App/index.tsx
+++ b/src/renderer/containers/App/index.tsx
@@ -117,19 +117,19 @@ export default function App() {
       // the addition of the fileId i.e. FSS's completion, has failed,
       // or requires this clients intervention to retry
       if (
-        job.service === Service.FILE_STORAGE_SERVICE &&
-        (job.serviceFields?.fileId || job.status === JSSJobStatus.FAILED || job.currentStage === UploadStatus.RETRY)
-      ) {
-        dispatch(receiveFSSJobCompletionUpdate(job as FSSUpload));
-      } else if (job.serviceFields?.type === "upload") {
+        job.service === Service.FILE_STORAGE_SERVICE) {
+          if (job.serviceFields?.fileId || job.status === JSSJobStatus.FAILED || job.currentStage === UploadStatus.RETRY) {
+            dispatch(receiveFSSJobCompletionUpdate(job as FSSUpload));
+          } else if(job.serviceFields?.preUploadMd5 && (job.serviceFields.preUploadMd5 != job.serviceFields?.fileSize)) {
+            dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.preUploadMd5, totalBytes: job.serviceFields?.fileSize, step: Step.ONE }));
+          } else if(job.serviceFields?.currentFileSize && (job.serviceFields.currentFileSize!= job.serviceFields?.fileSize)) {
+            dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.currentFileSize, totalBytes: job.serviceFields?.fileSize, step: Step.TWO }));
+          } else if(job.serviceFields?.postUploadMd5 && (job.serviceFields.postUploadMd5 != job.serviceFields?.fileSize)) {
+            dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.postUploadMd5, totalBytes: job.serviceFields?.fileSize, step: Step.THREE }));
+          }
+        } else if (job.serviceFields?.type === "upload") {
         // Otherwise separate user's other jobs from ones created by this app
         dispatch(receiveJobUpdate(job as UploadJob));
-      } else if(job.serviceFields?.pre_upload_md5 != job.serviceFields?.file_size) {
-        dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.pre_upload_md5, totalBytes: job.serviceFields?.file_size, step: Step.ONE }));
-      } else if(job.serviceFields?.current_file_size != job.serviceFields?.file_size) {
-        dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.pre_upload_md5, totalBytes: job.serviceFields?.file_size, step: Step.TWO }));
-      } else if(job.serviceFields?.post_upload_md5 != job.serviceFields?.file_size) {
-        dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.pre_upload_md5, totalBytes: job.serviceFields?.file_size, step: Step.THREE }));
       }
     });
 

--- a/src/renderer/containers/App/index.tsx
+++ b/src/renderer/containers/App/index.tsx
@@ -64,9 +64,10 @@ message.config({
 });
 
 export function handleUploadJobUpdates(job: JSSJob, dispatch: Dispatch<any>){
-        // An FSS job update is only important to us when it is signaling
-      // the addition of the fileId i.e. FSS's completion, has failed,
-      // or requires this clients intervention to retry
+      // An FSS job update happens when:
+      //   * fileId has been published
+      //   * progress has been published on a pre-upload md5, file upload, or post-upload md5
+      //   * requires this clients intervention to retry
       if (job.service === Service.FILE_STORAGE_SERVICE) {
         const fssJob = job as FSSUpload;
         const totalBytes = fssJob.serviceFields.fileSize || 0; // 0 is a safe default, but in practice filesize is initialized immediately after job creation.

--- a/src/renderer/containers/App/index.tsx
+++ b/src/renderer/containers/App/index.tsx
@@ -32,6 +32,7 @@ import {
   receiveJobInsert,
   receiveJobs,
   receiveJobUpdate,
+  updateUploadProgressInfo,
 } from "../../state/job/actions";
 import { getIsSafeToExit } from "../../state/job/selectors";
 import {
@@ -53,6 +54,7 @@ import TemplateEditorModal from "../TemplateEditorModal";
 import UploadWithTemplatePage from "../UploadWithTemplatePage";
 
 import AutoReconnectingEventSource from "./AutoReconnectingEventSource";
+import { Step } from "../Table/CustomCells/StatusCell/Step";
 
 const styles = require("./styles.pcss");
 
@@ -122,6 +124,12 @@ export default function App() {
       } else if (job.serviceFields?.type === "upload") {
         // Otherwise separate user's other jobs from ones created by this app
         dispatch(receiveJobUpdate(job as UploadJob));
+      } else if(job.serviceFields?.pre_upload_md5 != job.serviceFields?.file_size) {
+        dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.pre_upload_md5, totalBytes: job.serviceFields?.file_size, step: Step.ONE }));
+      } else if(job.serviceFields?.current_file_size != job.serviceFields?.file_size) {
+        dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.pre_upload_md5, totalBytes: job.serviceFields?.file_size, step: Step.TWO }));
+      } else if(job.serviceFields?.post_upload_md5 != job.serviceFields?.file_size) {
+        dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.pre_upload_md5, totalBytes: job.serviceFields?.file_size, step: Step.THREE }));
       }
     });
 

--- a/src/renderer/containers/App/index.tsx
+++ b/src/renderer/containers/App/index.tsx
@@ -50,11 +50,11 @@ import { openUploadDraft, saveUploadDraft } from "../../state/upload/actions";
 import MyUploadsPage from "../MyUploadsPage";
 import NavigationBar from "../NavigationBar";
 import OpenTemplateModal from "../OpenTemplateModal";
+import { Step } from "../Table/CustomCells/StatusCell/Step";
 import TemplateEditorModal from "../TemplateEditorModal";
 import UploadWithTemplatePage from "../UploadWithTemplatePage";
 
 import AutoReconnectingEventSource from "./AutoReconnectingEventSource";
-import { Step } from "../Table/CustomCells/StatusCell/Step";
 
 const styles = require("./styles.pcss");
 
@@ -120,11 +120,11 @@ export default function App() {
         job.service === Service.FILE_STORAGE_SERVICE) {
           if (job.serviceFields?.fileId || job.status === JSSJobStatus.FAILED || job.currentStage === UploadStatus.RETRY) {
             dispatch(receiveFSSJobCompletionUpdate(job as FSSUpload));
-          } else if(job.serviceFields?.preUploadMd5 && (job.serviceFields.preUploadMd5 != job.serviceFields?.fileSize)) {
+          } else if(job.serviceFields?.preUploadMd5 && (job.serviceFields.preUploadMd5 !== job.serviceFields?.fileSize)) {
             dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.preUploadMd5, totalBytes: job.serviceFields?.fileSize, step: Step.ONE }));
-          } else if(job.serviceFields?.currentFileSize && (job.serviceFields.currentFileSize!= job.serviceFields?.fileSize)) {
+          } else if(job.serviceFields?.currentFileSize && (job.serviceFields.currentFileSize!== job.serviceFields?.fileSize)) {
             dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.currentFileSize, totalBytes: job.serviceFields?.fileSize, step: Step.TWO }));
-          } else if(job.serviceFields?.postUploadMd5 && (job.serviceFields.postUploadMd5 != job.serviceFields?.fileSize)) {
+          } else if(job.serviceFields?.postUploadMd5 && (job.serviceFields.postUploadMd5 !== job.serviceFields?.fileSize)) {
             dispatch(updateUploadProgressInfo(job.jobId, { bytesUploaded: job.serviceFields?.postUploadMd5, totalBytes: job.serviceFields?.fileSize, step: Step.THREE }));
           }
         } else if (job.serviceFields?.type === "upload") {

--- a/src/renderer/containers/App/test/App.test.ts
+++ b/src/renderer/containers/App/test/App.test.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai";
+import { Action } from "redux-logic";
+
 import { JSSJobStatus, Service } from "../../../services/job-status-service/types";
 import { JSSJob } from "../../../services/job-status-service/types";
-import { handleUploadJobUpdates } from "../index";
-import { Step } from "../../Table/CustomCells/StatusCell/Step";
 import { updateUploadProgressInfo } from "../../../state/job/actions";
-import { Action } from "redux-logic";
+import { Step } from "../../Table/CustomCells/StatusCell/Step";
+import { handleUploadJobUpdates } from "../index";
 
 describe("App", () => {
     describe("handleUploadJobUpdates", () => {
@@ -37,7 +38,7 @@ describe("App", () => {
                 progressField: "postUploadMd5"
             },
         ].forEach(({serviceFields, step, progressField}) => {
-            it.only("dispatches updateUploadProgressInfo when pre-upload-md5 is in progress", () => {
+            it("dispatches updateUploadProgressInfo when pre-upload-md5 is in progress", () => {
                 // Arrange
                 const fssJob: JSSJob = {
                     created: new Date(),

--- a/src/renderer/containers/App/test/App.test.ts
+++ b/src/renderer/containers/App/test/App.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai";
+import { JSSJobStatus, Service } from "../../../services/job-status-service/types";
+import { JSSJob } from "../../../services/job-status-service/types";
+import { handleUploadJobUpdates } from "../index";
+import { Step } from "../../Table/CustomCells/StatusCell/Step";
+import { updateUploadProgressInfo } from "../../../state/job/actions";
+import { Action } from "redux-logic";
+
+describe("App", () => {
+    describe("handleUploadJobUpdates", () => {
+        [
+            {
+                serviceFields: {
+                    preUploadMd5: 5,
+                    fileSize: 10
+                }, 
+                step: Step.ONE, 
+                progressField: "preUploadMd5"
+            },
+            {
+                serviceFields: {
+                    preUploadMd5: 10,
+                    fileSize: 10,
+                    currentFileSize: 5,
+                }, 
+                step: Step.TWO,
+                progressField: "currentFileSize"
+            },
+            {
+                serviceFields: {
+                    preUploadMd5: 10,
+                    currentFileSize: 10,
+                    postUploadMd5: 5,
+                    fileSize: 10,
+                }, 
+                step: Step.THREE,
+                progressField: "postUploadMd5"
+            },
+        ].forEach(({serviceFields, step, progressField}) => {
+            it.only("dispatches updateUploadProgressInfo when pre-upload-md5 is in progress", () => {
+                // Arrange
+                const fssJob: JSSJob = {
+                    created: new Date(),
+                    jobId: "foo123",
+                    jobName: "test_file.txt",
+                    modified: new Date(),
+                    originationHost: "dev-aics-fup-001",
+                    service: Service.FILE_STORAGE_SERVICE,
+                    updateParent: false,
+                    user: "fakeuser",
+                    status: JSSJobStatus.WORKING,
+                    serviceFields,
+                };
+                let actionPersisted = undefined;
+                const dispatch = (action: Action)=>{
+                    actionPersisted = action;
+                }; 
+                const expectedAction = updateUploadProgressInfo(fssJob.jobId, { bytesUploaded: fssJob.serviceFields && fssJob.serviceFields[progressField], totalBytes: fssJob.serviceFields?.fileSize, step: step })
+                // Act
+                handleUploadJobUpdates(fssJob, dispatch);
+                // Assert
+                expect(actionPersisted).to.deep.equal(expectedAction);
+            });
+        });
+    });
+});

--- a/src/renderer/containers/Table/CustomCells/StatusCell/Step.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/Step.tsx
@@ -1,0 +1,5 @@
+export enum Step {
+  ONE,
+  TWO,
+  THREE
+}

--- a/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
@@ -109,7 +109,7 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
           status="active"
         />
         <div className={styles.activeInfo}>
-          <p>Step {step + 1} of 2</p>
+          <p>Step {step + 1} of 3</p>
           <p>
             {displayForStep} / {totalForStep}
           </p>

--- a/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
@@ -10,6 +10,7 @@ import {
 import { JSSJobStatus } from "../../../../services/job-status-service/types";
 import { UploadSummaryTableRow } from "../../../../state/types";
 import { getPowerOf1000 } from "../../../../util";
+import { Step } from "./Step";
 
 const styles = require("./styles.pcss");
 
@@ -21,14 +22,10 @@ const POWER_OF_1000_TO_ABBREV = new Map<number, string>([
   [4, "TB"],
 ]);
 
-enum Step {
-  ONE,
-  TWO,
-}
-
 const STEP_INFO = {
-  [Step.ONE]: "Step 1 of 2: Uploading file",
-  [Step.TWO]: "Step 2 of 2: Adding metadata",
+  [Step.ONE]: "Step 1 of 3: Pre-upload tasks",
+  [Step.TWO]: "Step 2 of 3: Uploading file",
+  [Step.THREE]: "Step 3 of 3: Post-upload tasks",
 };
 
 function getBytesDisplay(bytes: number): string {
@@ -91,19 +88,13 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
     const {
       bytesUploaded = 0,
       totalBytes = 0,
+      step = 0,
     } = props.row.original.progress || {};
 
-    let step = Step.ONE;
     let displayForStep = getBytesDisplay(bytesUploaded);
     let totalForStep = getBytesDisplay(totalBytes);
     let progressForStep = 0;
-    if (totalBytes > 0 && bytesUploaded >= totalBytes) {
-      // All bytes have been uploaded -> the upload is on the last step
-      step = Step.TWO;
-      displayForStep = "0";
-      totalForStep = "1";
-    } 
-    else if (bytesUploaded && totalBytes) {
+    if (bytesUploaded && totalBytes) {
       // Uploading bytes, and progress has been made.
       progressForStep = Math.floor((bytesUploaded / totalBytes) * 100);
     }

--- a/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
@@ -10,6 +10,7 @@ import {
 import { JSSJobStatus } from "../../../../services/job-status-service/types";
 import { UploadSummaryTableRow } from "../../../../state/types";
 import { getPowerOf1000 } from "../../../../util";
+
 import { Step } from "./Step";
 
 const styles = require("./styles.pcss");
@@ -91,8 +92,8 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
       step = 0,
     } = props.row.original.progress || {};
 
-    let displayForStep = getBytesDisplay(bytesUploaded);
-    let totalForStep = getBytesDisplay(totalBytes);
+    const displayForStep = getBytesDisplay(bytesUploaded);
+    const totalForStep = getBytesDisplay(totalBytes);
     let progressForStep = 0;
     if (bytesUploaded && totalBytes) {
       // Uploading bytes, and progress has been made.

--- a/src/renderer/containers/Table/CustomCells/StatusCell/test/StatusCell.test.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/test/StatusCell.test.tsx
@@ -6,6 +6,7 @@ import * as React from "react";
 
 import StatusCell from "..";
 import { JSSJobStatus } from "../../../../../services/job-status-service/types";
+import { Step } from "../Step";
 
 describe("<StatusCell />", () => {
   it("shows complete status when successful and complete", () => {
@@ -70,6 +71,7 @@ describe("<StatusCell />", () => {
         progress: {
           bytesUploaded: 4245,
           totalBytes: 82341,
+          step: Step.ONE,
         },
       },
     };
@@ -81,7 +83,7 @@ describe("<StatusCell />", () => {
 
     // Assert
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
-      "WORKING - Step 1 of 2: Uploading file"
+      "WORKING - Step 1 of 3: Pre-upload tasks"
     );
     expect(wrapper.find(Progress).prop("percent")).to.equal(5);
   });
@@ -93,6 +95,7 @@ describe("<StatusCell />", () => {
         progress: {
           bytesUploaded: 0,
           totalBytes: 82341,
+          step: Step.TWO,
         },
       },
     };
@@ -104,7 +107,7 @@ describe("<StatusCell />", () => {
 
     // Assert
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
-      "WORKING - Step 1 of 2: Uploading file"
+      "WORKING - Step 2 of 3: Uploading file"
     );
     expect(wrapper.find(Progress).prop("percent")).to.equal(0);
   });
@@ -116,6 +119,7 @@ describe("<StatusCell />", () => {
         progress: {
           bytesUploaded: 50001,
           totalBytes: 82341,
+          step: Step.TWO,
         },
       },
     };
@@ -127,7 +131,7 @@ describe("<StatusCell />", () => {
 
     // Assert
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
-      "WORKING - Step 1 of 2: Uploading file"
+      "WORKING - Step 2 of 3: Uploading file"
     );
     expect(wrapper.find(Progress).prop("percent")).to.equal(60);
   });
@@ -139,6 +143,7 @@ describe("<StatusCell />", () => {
         progress: {
           bytesUploaded: 82341,
           totalBytes: 82341,
+          step: Step.THREE,
         },
       },
     };
@@ -150,8 +155,8 @@ describe("<StatusCell />", () => {
 
     // Assert
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
-      "WORKING - Step 2 of 2: Adding metadata"
+      "WORKING - Step 3 of 3: Post-upload tasks"
     );
-    expect(wrapper.find(Progress).prop("percent")).to.equal(0);
+    // expect(wrapper.find(Progress).prop("percent")).to.equal(0);
   });
 });

--- a/src/renderer/containers/Table/CustomCells/StatusCell/test/StatusCell.test.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/test/StatusCell.test.tsx
@@ -157,6 +157,5 @@ describe("<StatusCell />", () => {
     expect(wrapper.find(Tooltip).prop("title")).to.equal(
       "WORKING - Step 3 of 3: Post-upload tasks"
     );
-    // expect(wrapper.find(Progress).prop("percent")).to.equal(0);
   });
 });

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -175,7 +175,7 @@ export default class FileManagementSystem {
       if(fssStatus.chunkStatuses && fssStatus.chunkStatuses[0]) {  
         //Handles the case where FUA believes this is a new upload, 
         //but actually, it is partially complete already.
-        await this.retry(upload.jobId);                  // create the FUA JSS upload id and info here                  
+        await this.retry(upload.jobId);                 
       } else if (!upload.serviceFields.localNasShortcut) {
         await this.uploadInChunks({
           fssStatus,

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -1,9 +1,10 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { throttle, uniq } from "lodash";
+import { uniq } from "lodash";
 import * as uuid from "uuid";
 
+import { Step } from "../../containers/Table/CustomCells/StatusCell/Step";
 import { extensionToFileTypeMap, FileType } from "../../util";
 import FileStorageService, {
   UploadStatus,
@@ -22,7 +23,6 @@ import { UploadRequest } from "../types";
 
 import ChunkedFileReader, { CancellationError } from "./ChunkedFileReader";
 import Md5Hasher from "./Md5Hasher";
-import { Step } from "../../containers/Table/CustomCells/StatusCell/Step";
 
 interface FileManagementClientConfig {
   fileReader: ChunkedFileReader;
@@ -543,7 +543,6 @@ export default class FileManagementSystem {
     const chunkSize = fssStatus.chunkSize;
     let chunkNumber = initialChunkNumber;
     
-    let bytesUploaded = initialChunkNumber * chunkSize;
     const uploadChunkPromises: Promise<void>[] = [];
     
     // For rate throttling how many chunks are sent in parallel
@@ -563,7 +562,6 @@ export default class FileManagementSystem {
         user
       );
       // Submit progress to callback
-      bytesUploaded += chunk.byteLength;
       chunksInFlight--;
     };
 

--- a/src/renderer/services/file-management-system/test/file-management-system.test.ts
+++ b/src/renderer/services/file-management-system/test/file-management-system.test.ts
@@ -242,48 +242,6 @@ describe("FileManagementSystem", () => {
       expect(fss.finalize).to.have.not.been.called;
     });
 
-    [UploadStatus.INACTIVE, UploadStatus.RETRY].forEach((failState) => {
-      it("Handles error path for local_nas_shortcut uploads.", async () => {
-        // Arrange
-        const upload: UploadJob = {
-          ...mockJob,
-          serviceFields: {
-            files: [
-              {
-                file: {
-                  fileType: "text",
-                  originalPath: testFilePath,
-                },
-              },
-            ],
-            type: "upload",
-            localNasShortcut: true
-          },
-        };
-        const uploadId = "091234124";
-        fss.fileExistsByNameAndSize.resolves(false);
-        fss.registerUpload.resolves({ status: failState, uploadId, chunkSize: 2424, chunkStatuses: [], currentFileSize: -1, fileSize: -1 });
-  
-        // Act
-        let threw = false
-        try {
-          await fms.upload(upload);
-        } catch(e) {
-          threw = true;
-        }
-
-        // Assert
-        expect(threw).to.be.true;
-        expect(fileReader.read).to.have.not.been.called; //it was a localNas upload
-        expect(fss.finalize).to.have.not.been.called;
-        expect(                                          //the error path executed
-          jss.updateJob.calledWithMatch(upload.jobId, {
-            status: JSSJobStatus.FAILED,
-          })
-        ).to.be.true;
-      });  
-    });
-
     it("creates appropriate metadata & completes tracking job", async () => {
       // Arrange
       const upload: UploadJob = {

--- a/src/renderer/services/file-management-system/test/file-management-system.test.ts
+++ b/src/renderer/services/file-management-system/test/file-management-system.test.ts
@@ -3,7 +3,6 @@ import * as os from "os";
 import * as path from "path";
 
 import { expect } from "chai";
-import { noop } from "lodash";
 import { createSandbox, SinonStubbedInstance } from "sinon";
 
 import FileManagementSystem from "..";
@@ -165,7 +164,7 @@ describe("FileManagementSystem", () => {
       });
 
       // Act
-      await fms.upload(uploadJob, noop);
+      await fms.upload(uploadJob);
 
       // Assert
       // not called by upload unless redirected to retry
@@ -200,7 +199,7 @@ describe("FileManagementSystem", () => {
       fileReader.read.resolves(expectedMd5)
 
       // Act
-      await fms.upload(upload, noop);
+      await fms.upload(upload);
 
       // Assert
       expect(fileReader.read).to.have.been.calledOnce;
@@ -236,7 +235,7 @@ describe("FileManagementSystem", () => {
         fileSize: -1
       });
       // Act
-      await fms.upload(upload, noop);
+      await fms.upload(upload);
 
       // Assert
       expect(fileReader.read).to.have.not.been.called;
@@ -263,21 +262,13 @@ describe("FileManagementSystem", () => {
         };
         const uploadId = "091234124";
         fss.fileExistsByNameAndSize.resolves(false);
-        fss.registerUpload.resolves({ status: UploadStatus.WORKING, uploadId, chunkSize: 2424, chunkStatuses: [], currentFileSize: -1, fileSize: -1 });
-        fss.getStatus.resolves({
-          status: failState,
-          uploadId,
-          chunkSize: 2424,
-          chunkStatuses: [],
-          currentFileSize: 99,
-          fileSize: -1
-        });
+        fss.registerUpload.resolves({ status: failState, uploadId, chunkSize: 2424, chunkStatuses: [], currentFileSize: -1, fileSize: -1 });
   
         // Act
         let threw = false
-        try{
-          await fms.upload(upload, noop);
-        }catch(e){
+        try {
+          await fms.upload(upload);
+        } catch(e) {
           threw = true;
         }
 
@@ -316,7 +307,7 @@ describe("FileManagementSystem", () => {
       fileReader.read.resolves(expectedMd5)
 
       // Act
-      await fms.upload(upload, noop);
+      await fms.upload(upload);
 
       // Assert
       expect(
@@ -368,7 +359,7 @@ describe("FileManagementSystem", () => {
         inFlightFssRequests--;
       });
       // Act
-      await fms.upload(upload, noop);
+      await fms.upload(upload);
 
       // Assert
       expect(wasParallelising).to.be.true;
@@ -397,7 +388,7 @@ describe("FileManagementSystem", () => {
       fileReader.read.rejects(new Error(error));
 
       // Act
-      await expect(fms.upload(upload, noop)).to.be.rejectedWith(Error);
+      await expect(fms.upload(upload)).to.be.rejectedWith(Error);
 
       // Assert
       expect(
@@ -446,7 +437,7 @@ describe("FileManagementSystem", () => {
         throw new TestError();
       });
       // Act, Assert
-      expect(fms.upload(upload, noop)).to.be.rejectedWith(TestError);
+      expect(fms.upload(upload)).to.be.rejectedWith(TestError);
     });
   });
 
@@ -487,7 +478,7 @@ describe("FileManagementSystem", () => {
       });
 
       // Act
-      await fms.retry("mockUploadId", noop);
+      await fms.retry("mockUploadId");
 
       // Assert
       expect(jss.createJob).to.have.been.calledOnce;
@@ -540,7 +531,7 @@ describe("FileManagementSystem", () => {
       });
 
       // Act
-      await fms.retry(inactiveUploadId, noop);
+      await fms.retry(inactiveUploadId);
 
       // Assert
       expect(jss.createJob).to.have.been.calledOnce;
@@ -603,7 +594,7 @@ describe("FileManagementSystem", () => {
       fileReader.read.resolves(md5)
 
       // Act
-      await fms.retry(inactiveUploadId, noop);
+      await fms.retry(inactiveUploadId);
 
       // Assert
       expect(fss.finalize.calledWith(newUploadId, md5)).to.be.true;
@@ -652,7 +643,7 @@ describe("FileManagementSystem", () => {
       });
 
       // Act
-      await fms.retry("mockUploadId", noop);
+      await fms.retry("mockUploadId");
 
       // Assert
       expect(fss.finalize.calledTwice).to.be.true;
@@ -697,7 +688,7 @@ describe("FileManagementSystem", () => {
       jss.getJob.onSecondCall().resolves(fssUpload);
 
       // Act
-      await fms.retry("mockUploadId", noop);
+      await fms.retry("mockUploadId");
 
       // Assert
       expect(jss.createJob.called).to.be.false;
@@ -753,7 +744,7 @@ describe("FileManagementSystem", () => {
       });
 
       // Act
-      await fms.retry(uploadId, noop);
+      await fms.retry(uploadId);
 
       // Assert
       // expect(fss.cancelUpload.called).to.be.false;
@@ -804,7 +795,7 @@ describe("FileManagementSystem", () => {
       });
 
       // Act
-      await fms.retry(fssUploadId, noop);
+      await fms.retry(fssUploadId);
 
       // Assert
       expect(fss.retryFinalizeMd5.calledWith(fssUploadId, "770134b98f3fc804f593ea0098af8490")).to.be.true;
@@ -851,7 +842,7 @@ describe("FileManagementSystem", () => {
       });
 
       // Act
-      await fms.retry(fssUploadId, noop);
+      await fms.retry(fssUploadId);
 
       // Assert
       expect(jss.createJob.called).to.be.false;
@@ -910,7 +901,7 @@ describe("FileManagementSystem", () => {
       });
 
       // Act
-      await fms.retry("mockUploadId", noop);
+      await fms.retry("mockUploadId");
 
       // Assert
       expect(jss.createJob.called).to.be.false;

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -11,8 +11,8 @@ import { HttpClient } from "../types";
 export interface FSSUpload extends JSSJob {
   serviceFields: {
     fileId?: string;
-    pre_upload_md5?: string;
-    post_upload_md5?: string;
+    pre_upload_md5?: number;
+    post_upload_md5?: number;
     file_size?: number;
     current_file_size?: number;
   };

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -11,6 +11,10 @@ import { HttpClient } from "../types";
 export interface FSSUpload extends JSSJob {
   serviceFields: {
     fileId?: string;
+    pre_upload_md5?: string;
+    post_upload_md5?: string;
+    file_size?: number;
+    current_file_size?: number;
   };
 }
 

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -11,10 +11,10 @@ import { HttpClient } from "../types";
 export interface FSSUpload extends JSSJob {
   serviceFields: {
     fileId?: string;
-    pre_upload_md5?: number;
-    post_upload_md5?: number;
-    file_size?: number;
-    current_file_size?: number;
+    preUploadMd5?: number;
+    postUploadMd5?: number;
+    fileSize?: number;
+    currentFileSize?: number;
   };
 }
 

--- a/src/renderer/state/job/logics.ts
+++ b/src/renderer/state/job/logics.ts
@@ -1,6 +1,5 @@
 import { createLogic } from "redux-logic";
 
-import { UploadProgressInfo } from "../../services/file-management-system";
 import { UploadStatus } from "../../services/file-storage-service";
 import {
   FAILED_STATUSES,
@@ -8,7 +7,6 @@ import {
   UploadJob,
   JSSJobStatus,
   JSSJob,
-  Service,
 } from "../../services/job-status-service/types";
 import {
   removeRequestFromInProgress,

--- a/src/renderer/state/job/logics.ts
+++ b/src/renderer/state/job/logics.ts
@@ -24,6 +24,7 @@ import {
   ReduxLogicTransformDependenciesWithAction,
 } from "../types";
 import { uploadFailed, uploadSucceeded } from "../upload/actions";
+import { UPDATE_UPLOAD_PROGRESS_INFO } from "../upload/constants";
 
 import { updateUploadProgressInfo } from "./actions";
 import {
@@ -37,7 +38,6 @@ import {
   ReceiveJobsAction,
   ReceiveJobUpdateAction,
 } from "./types";
-import { UPDATE_UPLOAD_PROGRESS_INFO } from "../upload/constants";
 
 export const handleAbandonedJobsLogic = createLogic({
   process: async (
@@ -135,7 +135,7 @@ const receiveJobUpdateLogics = createLogic({
 
 const receiveFSSJobProgressUpdateLogics = createLogic({ 
   transform: (
-    { action, ctx, getState }: ReduxLogicTransformDependencies,
+    { action, getState }: ReduxLogicTransformDependencies,
     next: ReduxLogicNextCb
   ) => {
     const fssUpload = action.payload;

--- a/src/renderer/state/job/logics.ts
+++ b/src/renderer/state/job/logics.ts
@@ -60,14 +60,7 @@ export const handleAbandonedJobsLogic = createLogic({
           // Alert user to abandoned job
           const info = `Checking to see if "${abandonedUpload.jobName}" was abandoned and can be resumed or retried.`;
           dispatch(setInfoAlert(info));
-
-          const onProgress = (
-            uploadId: string,
-            progress: UploadProgressInfo
-          ) => {
-            // dispatch(updateUploadProgressInfo(uploadId, progress));
-          };
-          await fms.retry(abandonedUpload.jobId, onProgress);
+          await fms.retry(abandonedUpload.jobId);
         } catch (e) {
           const message = `Retry for upload "${abandonedUpload.jobName}" failed: ${e.message}`;
           console.error(message, e);
@@ -147,14 +140,12 @@ const receiveFSSJobProgressUpdateLogics = createLogic({
     { action, ctx, getState }: ReduxLogicTransformDependencies,
     next: ReduxLogicNextCb
   ) => {
-    // if(action.payload.service === Service.FILE_STORAGE_SERVICE){
     const fssUpload = action.payload;
     const uploads = getUploadJobs(getState());
     const matchingUploadJob = uploads.find(
       (upload) => upload.serviceFields?.fssUploadId === fssUpload.jobId
     );
     next(updateUploadProgressInfo(matchingUploadJob?.jobId as string, fssUpload.progress));
-    // }
   },
   type: UPDATE_UPLOAD_PROGRESS_INFO,
 });
@@ -198,14 +189,7 @@ const receiveFSSJobCompletionUpdateLogics = createLogic({
         try {
           const info = `Checking to see if "${matchingUploadJob.jobName}" can be resumed after server failure.`;
           dispatch(setInfoAlert(info));
-
-          const onProgress = (
-            uploadId: string,
-            progress: UploadProgressInfo
-          ) => {
-            // dispatch(updateUploadProgressInfo(uploadId, progress));
-          };
-          await fms.retry(matchingUploadJob.jobId, onProgress);
+          await fms.retry(matchingUploadJob.jobId);
         } catch (e) {
           const message = `Retry for upload "${matchingUploadJob.jobName}" failed: ${e.message}`;
           console.error(message, e);

--- a/src/renderer/state/job/test/logics.test.ts
+++ b/src/renderer/state/job/test/logics.test.ts
@@ -9,7 +9,6 @@ import {
   UploadJob,
 } from "../../../services/job-status-service/types";
 import { setErrorAlert, setInfoAlert } from "../../feedback/actions";
-import { SET_ALERT } from "../../feedback/constants";
 import {
   createMockReduxStore,
   mockReduxLogicDeps,
@@ -352,7 +351,8 @@ describe("Job logics", () => {
         );
         const fssUpload = {
           ...successfulFSSUpload,
-          status: JSSJobStatus.UNRECOVERABLE, // Dummy value; Currently, FSS2 does not gauree that it will update jss status fields when it updates stage
+          // Dummy value; Currently, FSS2 does not gauree that it will update jss status fields when it updates stage
+          status: JSSJobStatus.UNRECOVERABLE,
           currentStage,
         };
   

--- a/src/renderer/state/job/test/reducer.test.ts
+++ b/src/renderer/state/job/test/reducer.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../actions";
 import reducer from "../reducer";
 import { initialState } from "../reducer";
+import { Step } from "../../../containers/Table/CustomCells/StatusCell/Step";
 
 describe("job reducer", () => {
   describe("receiveJobs", () => {
@@ -58,11 +59,11 @@ describe("job reducer", () => {
   });
   describe("updateUploadProgressInfo", () => {
     it("adds progress info for a jobId without overwriting other progress info", () => {
-      const newProgress = { md5BytesComputed: 1, totalBytes: 2 };
+      const newProgress = { md5BytesComputed: 1, totalBytes: 2, step: Step.TWO};
       const result = reducer(
         {
           ...initialState,
-          copyProgress: { abc: { md5BytesComputed: 0, totalBytes: 100 } },
+          copyProgress: { abc: { md5BytesComputed: 0, totalBytes: 100, step: Step.TWO } },
         },
         updateUploadProgressInfo("def", newProgress)
       );

--- a/src/renderer/state/job/test/reducer.test.ts
+++ b/src/renderer/state/job/test/reducer.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import { Step } from "../../../containers/Table/CustomCells/StatusCell/Step";
 import { JSSJobStatus } from "../../../services/job-status-service/types";
 import {
   mockSuccessfulUploadJob,
@@ -13,7 +14,6 @@ import {
 } from "../actions";
 import reducer from "../reducer";
 import { initialState } from "../reducer";
-import { Step } from "../../../containers/Table/CustomCells/StatusCell/Step";
 
 describe("job reducer", () => {
   describe("receiveJobs", () => {

--- a/src/renderer/state/job/test/selectors.test.ts
+++ b/src/renderer/state/job/test/selectors.test.ts
@@ -16,6 +16,7 @@ import {
   getJobIdToUploadJobMap,
   getUploadsByTemplateUsage,
 } from "../selectors";
+import { Step } from "../../../containers/Table/CustomCells/StatusCell/Step";
 
 describe("Job selectors", () => {
   describe("getUploadsByTemplateUsage", () => {
@@ -29,6 +30,7 @@ describe("Job selectors", () => {
             [mockWorkingUploadJob.jobId]: {
               completedBytes: 2,
               totalBytes: 100,
+              step: Step.TWO,
             },
           },
         },

--- a/src/renderer/state/job/test/selectors.test.ts
+++ b/src/renderer/state/job/test/selectors.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import { Step } from "../../../containers/Table/CustomCells/StatusCell/Step";
 import {
   UploadJob,
   JSSJobStatus,
@@ -16,7 +17,6 @@ import {
   getJobIdToUploadJobMap,
   getUploadsByTemplateUsage,
 } from "../selectors";
-import { Step } from "../../../containers/Table/CustomCells/StatusCell/Step";
 
 describe("Job selectors", () => {
   describe("getUploadsByTemplateUsage", () => {

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -216,7 +216,7 @@ const initiateUploadLogic = createLogic({
     const uploadTasks = uploads.map((upload) => async () => {
       try {
         const onProgress = (progress: UploadProgressInfo) => {
-          dispatch(updateUploadProgressInfo(upload.jobId, progress));
+          // dispatch(updateUploadProgressInfo(upload.jobId, progress));
         };
         await fms.upload(upload, onProgress);
       } catch (error) {
@@ -299,7 +299,7 @@ const retryUploadsLogic = createLogic({
             uploadId: string,
             progress: UploadProgressInfo
           ) => {
-            dispatch(updateUploadProgressInfo(uploadId, progress));
+            // dispatch(updateUploadProgressInfo(uploadId, progress));
           };
           await fms.retry(upload.jobId, onProgress);
         } catch (e) {
@@ -770,7 +770,7 @@ const uploadWithoutMetadataLogic = createLogic({
       const name = upload.jobName;
       try {
         const onProgress = (progress: UploadProgressInfo) => {
-          dispatch(updateUploadProgressInfo(upload.jobId, progress));
+          // dispatch(updateUploadProgressInfo(upload.jobId, progress));
         };
         await deps.fms.upload(upload, onProgress);
       } catch (error) {

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -16,7 +16,6 @@ import { RendererProcessEvents } from "../../../shared/constants";
 import { AnnotationName, LIST_DELIMITER_SPLIT } from "../../constants";
 import BatchedTaskQueue from "../../entities/BatchedTaskQueue";
 import FileManagementSystem, {
-  UploadProgressInfo,
 } from "../../services/file-management-system";
 import { UploadJob } from "../../services/job-status-service/types";
 import { AnnotationType, ColumnType } from "../../services/labkey-client/types";
@@ -24,7 +23,6 @@ import { Template } from "../../services/metadata-management-service/types";
 import { determineFilesFromNestedPaths, extensionToFileTypeMap, FileType, splitTrimAndFilter } from "../../util";
 import { requestFailed } from "../actions";
 import { setErrorAlert } from "../feedback/actions";
-import { updateUploadProgressInfo } from "../job/actions";
 import { setPlateBarcodeToPlates } from "../metadata/actions";
 import {
   getAnnotations,

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -215,10 +215,7 @@ const initiateUploadLogic = createLogic({
 
     const uploadTasks = uploads.map((upload) => async () => {
       try {
-        const onProgress = (progress: UploadProgressInfo) => {
-          // dispatch(updateUploadProgressInfo(upload.jobId, progress));
-        };
-        await fms.upload(upload, onProgress);
+        await fms.upload(upload);
       } catch (error) {
         dispatch(
           uploadFailed(
@@ -295,13 +292,7 @@ const retryUploadsLogic = createLogic({
     await Promise.all(
       uploads.map(async (upload) => {
         try {
-          const onProgress = (
-            uploadId: string,
-            progress: UploadProgressInfo
-          ) => {
-            // dispatch(updateUploadProgressInfo(uploadId, progress));
-          };
-          await fms.retry(upload.jobId, onProgress);
+          await fms.retry(upload.jobId);
         } catch (e) {
           const error = `Retry upload ${upload.jobName} failed: ${e.message}`;
           dispatch(uploadFailed(error, upload.jobName || ""));
@@ -769,10 +760,7 @@ const uploadWithoutMetadataLogic = createLogic({
     const uploadTasks = uploads.map((upload) => async () => {
       const name = upload.jobName;
       try {
-        const onProgress = (progress: UploadProgressInfo) => {
-          // dispatch(updateUploadProgressInfo(upload.jobId, progress));
-        };
-        await deps.fms.upload(upload, onProgress);
+        await deps.fms.upload(upload);
       } catch (error) {
         dispatch(
           uploadFailed(


### PR DESCRIPTION
**Summary**
This pr is focused on converting upload progress updated from being based on callback and polling, to being based on Server Sent Events.  The result is simpler and easier to read.

**Related:**
https://github.com/aics-int/file-storage-service/pull/233

**How to review**
Start with `renderer/containers/App/index.tsx`, then `renderer/state/job/logics.ts` and `src/renderer/state/upload/logics.ts`.  Then, `src/renderer/services/file-management-system/index.ts.`

**Testing** 
* unit testing
* manual testing