### PR TITLE
[#68] Add initial structure for supporting .sldy, .zarr uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,5 +143,8 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": "eslint --cache --fix"
+  },
+  "config": {
+    "networkTimeout": 180000 
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "compile-prod": "cross-env ELECTRON_WEBPACK_APP_LIMS_HOST=\"aics.corp.alleninstitute.org\" ELECTRON_WEBPACK_APP_LIMS_PORT=80 NODE_ENV=production yarn compile",
     "build-executable": "yarn compile && yarn electron-builder",
     "dist": "electron-builder -p always",
-    "test": "cross-env TS_NODE_PROJECT=tsconfig.commonjs.json TS_NODE_FILES=true NODE_ENV=production mocha --exit src/**/test/*.{ts,tsx}",
+    "test": "cross-env TS_NODE_PROJECT=tsconfig.commonjs.json TS_NODE_FILES=true NODE_ENV=production USE_MULTIFILE_ASSUMPTION=true mocha --exit src/**/test/*.{ts,tsx}",
     "postinstall": "electron-builder install-app-deps",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "madge": "madge --warning --circular --ts-config tsconfig.base.json --webpack-config webpack/webpack.render.additions.js --extensions js,jsx,ts,tsx  src/",

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -120,16 +120,13 @@ export default class FileManagementSystem {
     const source = upload.serviceFields.files[0]?.file.originalPath;
     const fileName = path.basename(source);
     const isMultifile = upload.serviceFields.multifile || false;
-    const statReturn = await fs.promises.stat(source);
-    const fileLastModified = statReturn.mtime;
 
-    let fileSize: number;
+    let { size: fileSize, mtime: fileLastModified } = await fs.promises.stat(source);
+
     // Multifile uploads require us to get the total size of all relevant sub-files
     // For any other upload, we can just grab the size returned by fs
     if (isMultifile) {
       fileSize = await getDirectorySize(source);
-    } else {
-      fileSize = statReturn.size;
     }
 
     const fileLastModifiedInMs = fileLastModified.getTime();

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -121,7 +121,9 @@ export default class FileManagementSystem {
     const fileName = path.basename(source);
     const isMultifile = upload.serviceFields.multifile || false;
 
-    let { size: fileSize, mtime: fileLastModified } = await fs.promises.stat(source);
+    const sourceStat = await fs.promises.stat(source);
+    let { size: fileSize } = sourceStat;
+    const { mtime: fileLastModified } = sourceStat
 
     // Multifile uploads require us to get the total size of all relevant sub-files
     // For any other upload, we can just grab the size returned by fs

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -113,7 +113,7 @@ export default class FileStorageService extends HttpCacheClient {
       file_size: fileSize,
       local_nas_shortcut: localNasPath !== undefined,
       local_nas_path: localNasPath,
-      multifile :!!isMultifile,
+      multifile: !!isMultifile,
     };
     return this.post<UploadStatusResponse>(
       url,

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -113,7 +113,7 @@ export default class FileStorageService extends HttpCacheClient {
       file_size: fileSize,
       local_nas_shortcut: localNasPath !== undefined,
       local_nas_path: localNasPath,
-      multifile: isMultifile !== undefined ? isMultifile : false,
+      multifile :!!isMultifile,
     };
     return this.post<UploadStatusResponse>(
       url,

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -100,6 +100,7 @@ export default class FileStorageService extends HttpCacheClient {
     fileType: FileType,
     fileSize: number,
     localNasPath?: string,
+    isMultifile?: boolean,
   ): Promise<UploadStatusResponse> {
     const url = `${FileStorageService.BASE_UPLOAD_PATH}/register`;
     const postBody = {
@@ -111,7 +112,8 @@ export default class FileStorageService extends HttpCacheClient {
       // so the conversion must be manual each request
       file_size: fileSize,
       local_nas_shortcut: localNasPath !== undefined,
-      local_nas_path: localNasPath
+      local_nas_path: localNasPath,
+      multifile: isMultifile !== undefined ? isMultifile : false,
     };
     return this.post<UploadStatusResponse>(
       url,

--- a/src/renderer/services/file-storage-service/test/file-storage-service.test.ts
+++ b/src/renderer/services/file-storage-service/test/file-storage-service.test.ts
@@ -48,7 +48,8 @@ describe("FileStorageService", () => {
         file_type: fileType,
         file_size: fileSize,
         local_nas_path: undefined,
-        local_nas_shortcut: false
+        local_nas_shortcut: false,
+        multifile: false
       };
       sandbox.replace(httpClient, "post", postStub as SinonStub<any>);
 
@@ -83,7 +84,8 @@ describe("FileStorageService", () => {
         file_type: fileType,
         file_size: fileSize,
         local_nas_path: localNasPath,
-        local_nas_shortcut: true
+        local_nas_shortcut: true,
+        multifile: false
       };
       sandbox.replace(httpClient, "post", postStub as SinonStub<any>);
 

--- a/src/renderer/services/job-status-service/types.ts
+++ b/src/renderer/services/job-status-service/types.ts
@@ -63,6 +63,9 @@ export interface UploadServiceFields {
 
   // Controls whether the file is send over the network in chunks, or if it is accessible directly via a path on the local NAS.
   localNasShortcut?: boolean;
+
+  // Determines whether an uploaded folder should be interpreted as a "multifile".
+  multifile?: boolean;
 }
 
 export interface JSSJob {

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -1,7 +1,7 @@
 import { createLogic } from "redux-logic";
 
 import { AnnotationName } from "../../constants";
-import {determineFilesFromNestedPaths, determineIsMultifile} from "../../util";
+import { determineFilesFromNestedPaths, determineIsMultifile } from "../../util";
 import { setAlert, startLoading, stopLoading } from "../feedback/actions";
 import { getBooleanAnnotationTypeId } from "../metadata/selectors";
 import { getAppliedTemplate } from "../template/selectors";

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -42,11 +42,9 @@ const loadFilesLogic = createLogic({
   ) => {
     dispatch(startLoading());
     try {
-      const filePaths = await Promise.all(deps.action.payload.map(async (filePath) => {
-        const isMultifile = determineIsMultifile(filePath);
-        // todo determineFilesFromNestedPaths first arg may not need to be an array?
-        return await determineFilesFromNestedPaths([filePath], isMultifile);
-      }));
+      const filePaths = await determineFilesFromNestedPaths(
+        deps.action.payload
+      );
       dispatch(stopLoading());
       dispatch(addUploadFiles(filePaths.flat().map((file) => ({ file }))));
       done();

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -1,7 +1,7 @@
 import { createLogic } from "redux-logic";
 
 import { AnnotationName } from "../../constants";
-import { determineFilesFromNestedPaths, determineIsMultifile } from "../../util";
+import { determineFilesFromNestedPaths } from "../../util";
 import { setAlert, startLoading, stopLoading } from "../feedback/actions";
 import { getBooleanAnnotationTypeId } from "../metadata/selectors";
 import { getAppliedTemplate } from "../template/selectors";

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -726,11 +726,9 @@ const uploadWithoutMetadataLogic = createLogic({
 
     let uploads: UploadJob[];
     try {
-      const filePaths = await Promise.all(deps.action.payload.map(async (filePath) => {
-        const isMultifile = determineIsMultifile(filePath);
-        // todo determineFilesFromNestedPaths first arg may not need to be an array?
-        return await determineFilesFromNestedPaths([filePath], isMultifile);
-      }));
+      const filePaths = await determineFilesFromNestedPaths(
+        deps.action.payload
+      );
       uploads = await Promise.all(
           filePaths.flat().map((filePath) => {
             const isMultifile = determineIsMultifile(filePath); // todo: simplify this whole function so this isn't called twice

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -12,7 +12,13 @@ import FileManagementSystem from "../../services/file-management-system";
 import {UploadJob} from "../../services/job-status-service/types";
 import {AnnotationType, ColumnType} from "../../services/labkey-client/types";
 import {Template} from "../../services/metadata-management-service/types";
-import {determineFilesFromNestedPaths, extensionToFileTypeMap, FileType, splitTrimAndFilter} from "../../util";
+import {
+  determineFilesFromNestedPaths,
+  determineIsMultifile,
+  extensionToFileTypeMap,
+  FileType,
+  splitTrimAndFilter
+} from "../../util";
 import {requestFailed} from "../actions";
 import {setErrorAlert} from "../feedback/actions";
 import {setPlateBarcodeToPlates} from "../metadata/actions";
@@ -687,23 +693,6 @@ const submitFileMetadataUpdateLogic = createLogic({
   },
   type: SUBMIT_FILE_METADATA_UPDATE,
 });
-
-/**
- * Use a given filepath's extension to determine if it is a "multifile".
- * @param filePath Path to the file
- */
-function determineIsMultifile(filePath: string): boolean {
-  const multifileExtensions = ['.zarr', '.sldy'];
-  const combinedExtensions = multifileExtensions.join('|');
-
-  // "ends with one of the listed extensions, ignoring casing"
-  // otherwise written like: /.zarr|.sldy$/i
-  const matcher = new RegExp(combinedExtensions + "$", 'i');
-
-  // If the regex matches it will return an array (truthy).
-  // If the regex doesn't match it will return null (falsy).
-  return Boolean(filePath.match(matcher));
-}
 
 const uploadWithoutMetadataLogic = createLogic({
   process: async (

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -1,17 +1,25 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import {castArray, flatMap, forEach, get, isNil, trim,} from "lodash";
-import {isDate, isMoment} from "moment";
-import {createLogic} from "redux-logic";
+import {
+  castArray,
+  flatMap,
+  forEach,
+  get,
+  isNil,
+  trim,
+} from "lodash";
+import { isDate, isMoment } from "moment";
+import { createLogic } from "redux-logic";
 
-import {RendererProcessEvents} from "../../../shared/constants";
-import {AnnotationName, LIST_DELIMITER_SPLIT} from "../../constants";
+import { RendererProcessEvents } from "../../../shared/constants";
+import { AnnotationName, LIST_DELIMITER_SPLIT } from "../../constants";
 import BatchedTaskQueue from "../../entities/BatchedTaskQueue";
-import FileManagementSystem from "../../services/file-management-system";
-import {UploadJob} from "../../services/job-status-service/types";
-import {AnnotationType, ColumnType} from "../../services/labkey-client/types";
-import {Template} from "../../services/metadata-management-service/types";
+import FileManagementSystem, {
+} from "../../services/file-management-system";
+import { UploadJob } from "../../services/job-status-service/types";
+import { AnnotationType, ColumnType } from "../../services/labkey-client/types";
+import { Template } from "../../services/metadata-management-service/types";
 import {
   determineFilesFromNestedPaths,
   determineIsMultifile,
@@ -19,9 +27,9 @@ import {
   FileType,
   splitTrimAndFilter
 } from "../../util";
-import {requestFailed} from "../actions";
-import {setErrorAlert} from "../feedback/actions";
-import {setPlateBarcodeToPlates} from "../metadata/actions";
+import { requestFailed } from "../actions";
+import { setErrorAlert } from "../feedback/actions";
+import { setPlateBarcodeToPlates } from "../metadata/actions";
 import {
   getAnnotations,
   getAnnotationTypes,
@@ -31,14 +39,21 @@ import {
   getDateTimeAnnotationTypeId,
   getPlateBarcodeToPlates,
 } from "../metadata/selectors";
-import {closeUpload, resetUpload, viewUploads} from "../route/actions";
-import {handleStartingNewUploadJob} from "../route/logics";
-import {updateMassEditRow} from "../selection/actions";
-import {getMassEditRow, getSelectedUploads, getSelectedUser,} from "../selection/selectors";
-import {getTemplateId} from "../setting/selectors";
-import {ensureDraftGetsSaved, getApplyTemplateInfo,} from "../stateHelpers";
-import {setAppliedTemplate} from "../template/actions";
-import {getAppliedTemplate} from "../template/selectors";
+import { closeUpload, viewUploads, resetUpload } from "../route/actions";
+import { handleStartingNewUploadJob } from "../route/logics";
+import { updateMassEditRow } from "../selection/actions";
+import {
+  getMassEditRow,
+  getSelectedUploads,
+  getSelectedUser,
+} from "../selection/selectors";
+import { getTemplateId } from "../setting/selectors";
+import {
+  ensureDraftGetsSaved,
+  getApplyTemplateInfo,
+} from "../stateHelpers";
+import { setAppliedTemplate } from "../template/actions";
+import { getAppliedTemplate } from "../template/selectors";
 import {
   AsyncRequest,
   FileModel,
@@ -50,7 +65,7 @@ import {
   ReduxLogicRejectCb,
   ReduxLogicTransformDependenciesWithAction,
 } from "../types";
-import {batchActions} from "../util";
+import { batchActions } from "../util";
 
 import {
   addUploadFiles,
@@ -78,7 +93,12 @@ import {
   UPDATE_UPLOAD_ROWS,
   UPLOAD_WITHOUT_METADATA,
 } from "./constants";
-import {getCanSaveUploadDraft, getUpload, getUploadFileNames, getUploadRequests,} from "./selectors";
+import {
+  getCanSaveUploadDraft,
+  getUpload,
+  getUploadFileNames,
+  getUploadRequests,
+} from "./selectors";
 import {
   ApplyTemplateAction,
   CancelUploadAction,

--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -7,6 +7,15 @@ import { flatten, memoize, uniq } from "lodash";
 
 import { LIST_DELIMITER_SPLIT, MAIN_FONT_WIDTH } from "../constants";
 
+///////////////////////////////////////////////////////////////////
+// TODO - Remove this once multifile support is feature-complete //
+//         Flip the boolean to "true" for testing                //
+///////////////////////////////////////////////////////////////////
+
+const USE_MULTIFILE_ASSUMPTION = false;
+
+///////////////////////////////////////////////////////////////////
+
 /*
  * This file contains pure utility methods with no dependencies on other code
  * in this repo.
@@ -83,7 +92,7 @@ export function determineIsMultifile(filePath: string): boolean {
 
   // If the regex matches it will return an array (truthy).
   // If the regex doesn't match it will return null (falsy).
-  return Boolean(filePath.match(matcher));
+  return Boolean(filePath.match(matcher)) && USE_MULTIFILE_ASSUMPTION;
 }
 
 /**

--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -7,15 +7,6 @@ import { flatten, memoize, uniq } from "lodash";
 
 import { LIST_DELIMITER_SPLIT, MAIN_FONT_WIDTH } from "../constants";
 
-///////////////////////////////////////////////////////////////////
-// TODO - Remove this once multifile support is feature-complete //
-//         Flip the boolean to "true" for testing                //
-///////////////////////////////////////////////////////////////////
-
-const USE_MULTIFILE_ASSUMPTION = false;
-
-///////////////////////////////////////////////////////////////////
-
 /*
  * This file contains pure utility methods with no dependencies on other code
  * in this repo.
@@ -83,6 +74,15 @@ export async function determineFilesFromNestedPaths(
  * @param filePath Path to the file
  */
 export function determineIsMultifile(filePath: string): boolean {
+  ///////////////////////////////////////////////////////////////////
+  // TODO - Remove this once multifile support is feature-complete //
+  //         Flip the boolean to "true" for testing                //
+  ///////////////////////////////////////////////////////////////////
+  const USE_MULTIFILE_ASSUMPTION = process.env.USE_MULTIFILE_ASSUMPTION !== undefined
+      ? process.env.USE_MULTIFILE_ASSUMPTION === 'true'
+      : false;
+  ///////////////////////////////////////////////////////////////////
+
   const multifileExtensions = ['.zarr', '.sldy'];
   const combinedExtensions = multifileExtensions.join('|');
 

--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -34,6 +34,13 @@ const canUserRead = async (filePath: string): Promise<boolean> => {
   }
 };
 
+/**
+ * For a given path, determine whether it constitutes a single FMS Upload item (for File, Multifile uploads) or
+ *   a collection of multiple files each with their own FMS entry (for Directory uploads).
+ * For Directory files, only immediate children of the given directory are returned (i.e. files in sub-directories
+ *   are not included).
+ * @param path Local file path for an upload target
+ */
 async function determineFilesFromNestedPath(
   path: string
 ): Promise<string[]> {

--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -38,12 +38,13 @@ const canUserRead = async (filePath: string): Promise<boolean> => {
 // if so it extracts the file paths for the files within said directory
 // otherwise just returns the file path as is.
 export async function determineFilesFromNestedPaths(
-  paths: string[]
+  paths: string[],
+  isMultifile: boolean
 ): Promise<string[]> {
   const filePaths = await Promise.all(
     paths.flatMap(async (fullPath) => {
       const stats = await fsPromises.stat(fullPath);
-      if (!stats.isDirectory()) {
+      if (!stats.isDirectory() || isMultifile) {
         return [fullPath];
       }
       const canRead = await canUserRead(fullPath);

--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -64,6 +64,23 @@ export async function determineFilesFromNestedPaths(
 }
 
 /**
+ * Use a given filepath's extension to determine if it is a "multifile".
+ * @param filePath Path to the file
+ */
+export function determineIsMultifile(filePath: string): boolean {
+  const multifileExtensions = ['.zarr', '.sldy'];
+  const combinedExtensions = multifileExtensions.join('|');
+
+  // "ends with one of the listed extensions, ignoring casing"
+  // otherwise written like: /.zarr|.sldy$/i
+  const matcher = new RegExp(combinedExtensions + "$", 'i');
+
+  // If the regex matches it will return an array (truthy).
+  // If the regex doesn't match it will return null (falsy).
+  return Boolean(filePath.match(matcher));
+}
+
+/**
  * Returns the total size of a given directory's children, sub-children, etc.
  * If the given path points to a file rather than a directory, returns the size of the file.
  * @param dir Local path to a directory.

--- a/src/renderer/util/test/index.test.ts
+++ b/src/renderer/util/test/index.test.ts
@@ -35,7 +35,7 @@ describe("General utilities", () => {
 
     it("returns files as is", async () => {
       // Act
-      const result = await determineFilesFromNestedPaths([MOCK_FILE1]);
+      const result = await determineFilesFromNestedPaths([MOCK_FILE1], false); // todo multifile determination should probably be done within this function
 
       // Assert
       expect(result).to.deep.equal([MOCK_FILE1]);
@@ -46,7 +46,7 @@ describe("General utilities", () => {
       const result = await determineFilesFromNestedPaths([
         MOCK_DIRECTORY,
         MOCK_FILE1,
-      ]);
+      ], false); // todo multifile determination should probably be done within this function
 
       // Assert
       expect(result).to.deep.equal([MOCK_FILE1, MOCK_FILE2]);

--- a/src/renderer/util/test/index.test.ts
+++ b/src/renderer/util/test/index.test.ts
@@ -37,7 +37,7 @@ describe("General utilities", () => {
 
     it("returns files as is", async () => {
       // Act
-      const result = await determineFilesFromNestedPaths([MOCK_FILE1], false); // todo multifile determination should probably be done within this function
+      const result = await determineFilesFromNestedPaths([MOCK_FILE1]);
 
       // Assert
       expect(result).to.deep.equal([MOCK_FILE1]);
@@ -48,7 +48,7 @@ describe("General utilities", () => {
       const result = await determineFilesFromNestedPaths([
         MOCK_DIRECTORY,
         MOCK_FILE1,
-      ], false); // todo multifile determination should probably be done within this function
+      ]);
 
       // Assert
       expect(result).to.deep.equal([MOCK_FILE1, MOCK_FILE2]);

--- a/src/renderer/util/test/index.test.ts
+++ b/src/renderer/util/test/index.test.ts
@@ -9,6 +9,7 @@ import { restore } from "sinon";
 import {
   determineFilesFromNestedPaths,
   determineIsMultifile,
+  getDirectorySize,
   getPowerOf1000,
   splitTrimAndFilter,
 } from "../";
@@ -52,6 +53,39 @@ describe("General utilities", () => {
       // Assert
       expect(result).to.deep.equal([MOCK_FILE1, MOCK_FILE2]);
     });
+  });
+
+  describe("getDirectorySize", () => {
+    const MOCK_DIRECTORY = path.resolve(os.tmpdir(), "fuaMockTest");
+
+    after(() => {
+      rimraf.sync(MOCK_DIRECTORY);
+    });
+
+    it("correctly calculates directory size", async () => {
+      // Arrange
+      // create a directory containing one file and a sub-directory that also contains one file
+      await fs.promises.mkdir(MOCK_DIRECTORY);
+
+      const SUB_DIR = path.resolve(MOCK_DIRECTORY, "subDir");
+      await fs.promises.mkdir(SUB_DIR);
+
+      const FILE_1 = path.resolve(MOCK_DIRECTORY, "file1.txt");
+      const FILE_2 = path.resolve(SUB_DIR, "file2.txt");
+
+      // use a 10 byte array to create files that are each 10 bytes
+      const byteArray = new Int8Array(10);
+
+      await fs.promises.writeFile(FILE_1, byteArray);
+      await fs.promises.writeFile(FILE_2, byteArray)
+
+      // Act
+      const result = await getDirectorySize(MOCK_DIRECTORY);
+
+      // Assert
+      // two 10-byte files -> 20 bytes total size
+      expect(result).to.equal(20);
+    })
   });
 
   describe("determineIsMultifile", () => {

--- a/src/renderer/util/test/index.test.ts
+++ b/src/renderer/util/test/index.test.ts
@@ -8,6 +8,7 @@ import { restore } from "sinon";
 
 import {
   determineFilesFromNestedPaths,
+  determineIsMultifile,
   getPowerOf1000,
   splitTrimAndFilter,
 } from "../";
@@ -50,6 +51,33 @@ describe("General utilities", () => {
 
       // Assert
       expect(result).to.deep.equal([MOCK_FILE1, MOCK_FILE2]);
+    });
+  });
+
+  describe("determineIsMultifile", () => {
+    it("returns true when files have expected extensions", () => {
+      // Arrange
+      const MOCK_FILE1 = "file.sldy";
+      const MOCK_FILE2 = "file.zarr";
+
+      // Act
+      const result1 = determineIsMultifile(MOCK_FILE1);
+      const result2 = determineIsMultifile(MOCK_FILE2);
+
+      // Assert
+      expect(result1).to.equal(true);
+      expect(result2).to.equal(true);
+    });
+
+    it("returns false when files do not have expected extensions", () => {
+      // Arrange
+      const MOCK_FILE1 = "image.png";
+
+      // Act
+      const result = determineIsMultifile(MOCK_FILE1);
+
+      // Assert
+      expect(result).to.equal(false);
     });
   });
 


### PR DESCRIPTION
### Context
For a long time now, the science teams have wanted to upload particular file types to FMS - those file types are (at minimum) `.sldy` and `.zarr` files, which are "multifiles", AKA special directory structures that may be interpreted as a single file format.

We've gotten to the point where FSS can support multifile uploads, so naturally the next step is to update our FSS clients to do the same.

### Changes
* Added an expectation of an envvar called `USE_MULTIFILE_ASSUMPTION` to toggle multifile support on and off
   *  For testing purposes until multifile support is 100% ready for users to get their hands on, per request.
* When multifile support is enabled, directory uploads are checked to see if the name of the given directory ends in an expected file extension. Multifiles then appear as a single entry in the "My Uploads" table.
   * I have not interviewed people to find out if there are any multifile formats for us to expect beyond `.zarr` and `.sldy`, but adding to the list should be easy.
 *  If an upload is determined to be a multifile, then the FSS `/register` requests have `multifile: true` added to them
 * Multifile uploads have `multifile: true` in their JSS job `serviceFields`, which is then read in `fms.register()`. This should mean upload retries will work correctly.

### Testing
* Added unit tests for new `util` functions
* Manual testing via the UI
  * If you want to do this yourself, flip the boolean mentioned above -> run the app locally (`yarn dev`) -> upload any directory named `<whatever>.sldy` or `.zarr`.

### Reviewing
The changes really aren't too big. For review, I would probably check out the new methods in `src/renderer/util/index.ts` first, then look at `state/upload/logics.ts`, then the FMS / FSS service files. 

### TODO
* In this PR
  * There may be a straggling TODO I left in here.
  * Comment for one of the functions I touched in `util`.
  * Any unit test ideas that come to mind.
* As separate work
  * Multifile progress reporting in FSS and the upload app 
  * Talking to users to make sure multifile uploads work as they would expect.

### Notes
There's something smelly about the upload logic structure in the FUA - I haven't quite mapped it out yet, but I think we could re-use more of our code between uploading files with or without annotations / metadata.