### PR TITLE
[FUA-70] Fix DateTime picker

### DIFF
--- a/src/renderer/containers/Table/Editors/DateEditor/index.tsx
+++ b/src/renderer/containers/Table/Editors/DateEditor/index.tsx
@@ -1,6 +1,6 @@
 import { DeleteOutlined } from "@ant-design/icons";
 import { Button, DatePicker } from "antd";
-import moment from "moment";
+import moment, {Moment} from "moment";
 import React, { useState } from "react";
 import { ColumnInstance } from "react-table";
 
@@ -23,12 +23,12 @@ export default function DateEditor({
   column,
   commitChanges,
 }: Props) {
-  const [value, setValue] = useState<Date | undefined>(
-    initialValue.length > 0 ? initialValue[0] : undefined
+  const [value, setValue] = useState<Moment | undefined>(
+    initialValue.length > 0 ? moment(initialValue[0]) : undefined
   );
 
-  function handleCommit() {
-    commitChanges(value ? [value] : []);
+  function handleCommit(moment: Moment | undefined) {
+      commitChanges(moment ? [moment.toDate()] : []);
   }
 
   function handleBlur(e: React.FocusEvent<HTMLDivElement>) {
@@ -41,7 +41,7 @@ export default function DateEditor({
         (e.relatedTarget.tagName !== "LI" ||
           e.relatedTarget.attributes.getNamedItem("role")?.value !== "button"))
     ) {
-      handleCommit();
+        handleCommit(value);
     }
   }
 
@@ -50,12 +50,12 @@ export default function DateEditor({
       <DatePicker
         open
         autoFocus
-        onOk={handleCommit}
+        onOk={(moment) => handleCommit(moment)} // only present for DateTime types
         className={styles.datePicker}
         showTime={column.type === ColumnType.DATETIME}
         placeholder="Add a Date"
-        value={value ? moment(value).utc() : undefined}
-        onChange={(selectedValue) => setValue(selectedValue?.toDate() ?? undefined)}
+        value={value ? value.utc() : undefined}
+        onChange={(selectedValue) => setValue(selectedValue ?? undefined)}
         renderExtraFooter={() => (
           <div className={styles.footer}>
             <Button

--- a/src/renderer/containers/Table/Editors/DateEditor/index.tsx
+++ b/src/renderer/containers/Table/Editors/DateEditor/index.tsx
@@ -1,6 +1,6 @@
 import { DeleteOutlined } from "@ant-design/icons";
 import { Button, DatePicker } from "antd";
-import moment, {Moment} from "moment";
+import moment, { Moment } from "moment";
 import React, { useState } from "react";
 import { ColumnInstance } from "react-table";
 

--- a/src/renderer/containers/Table/Editors/DateEditor/index.tsx
+++ b/src/renderer/containers/Table/Editors/DateEditor/index.tsx
@@ -28,7 +28,7 @@ export default function DateEditor({
   );
 
   function handleCommit(moment: Moment | undefined) {
-      commitChanges(moment ? [moment.toDate()] : []);
+    commitChanges(moment ? [moment.toDate()] : []);
   }
 
   function handleBlur(e: React.FocusEvent<HTMLDivElement>) {
@@ -41,7 +41,7 @@ export default function DateEditor({
         (e.relatedTarget.tagName !== "LI" ||
           e.relatedTarget.attributes.getNamedItem("role")?.value !== "button"))
     ) {
-        handleCommit(value);
+      handleCommit(value);
     }
   }
 


### PR DESCRIPTION
### Context

Antoine tried to use the "argolight optical control" template when uploading a file and ran into an issue where the "Imaging Date" annotation would not correctly populate its value in the upload grid after pressing "OK". We then confirmed that all of the annotations with the DateTime annotation type have the same issue.

### Bug
The `<DateEditor>` component is basically just a wrapper around an antd component (antd is a big library we use all over the FUA). The antd component is intended to be super flexible and support multiple types of datetime entries, from ranges to dates to datetimes, etc. Thing is, its behavior changes quite a bit depending on what props you feed it.

This issue arose because we passed a function to the component's `onOk` prop, but didn't properly consume the parameter that it passed in. Kinda like this:

```
// inside the antd component
const innerFunction = (event, callbackFn) => {
    callbackFn(event.target.value);
}

// in our code
const callbackFn = () => {
    console.log("I don't take any arguments lol");
} 
```

### Changes
* In `<DateEditor>`
   * `handleCommit()` is now `handleCommit(moment)`
   *  Inner value tracked in state is now a `moment` object rather than a `Date` object.

### Testing
Only tested manually, but I'm very open to any unit test ideas.