### PR TITLE
[FUA-72] Convert Datetime annotation values to ISO strings when submitting metadata to FMS.

### DIFF
--- a/src/renderer/state/upload/selectors.ts
+++ b/src/renderer/state/upload/selectors.ts
@@ -405,7 +405,7 @@ const getAnnotations = (
             annotationId: annotation.annotationId,
             values: castArray(value).map((v) => {
               if (annotation.type === ColumnType.DATETIME) {
-                return moment(v).toISOString();
+                return moment(v).format(); // ISO string w/ timezone offset
               }
               if (annotation.type === ColumnType.DATE) {
                 return moment(v).format("YYYY-MM-DD");

--- a/src/renderer/state/upload/selectors.ts
+++ b/src/renderer/state/upload/selectors.ts
@@ -405,7 +405,7 @@ const getAnnotations = (
             annotationId: annotation.annotationId,
             values: castArray(value).map((v) => {
               if (annotation.type === ColumnType.DATETIME) {
-                return moment(v).format("YYYY-MM-DD HH:mm:ss");
+                return moment(v).toISOString();
               }
               if (annotation.type === ColumnType.DATE) {
                 return moment(v).format("YYYY-MM-DD");

--- a/src/renderer/state/upload/test/selectors.test.ts
+++ b/src/renderer/state/upload/test/selectors.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { orderBy } from "lodash";
 
+
 import { AnnotationName } from "../../../constants";
 import { TemplateAnnotation } from "../../../services/metadata-management-service/types";
 import { UploadRequest } from "../../../services/types";
@@ -150,7 +151,15 @@ describe("Upload selectors", () => {
       const actual = getUploadRequests(state);
       expect(actual).to.deep.equal(expectedPayload);
     });
-    it("Converts DateTime annotation values into properly-formatted ISO strings", () => {
+    it("Converts DateTime annotation values into properly-formatted ISO strings with timezone offsets", () => {
+      // This is pretty much the same thing that happens in the selector function that's being tested.
+      // But a) because of daylight savings, the timezone offset changes depending on the time of year, so we can't just
+      //   hardcode an "expected" value in the test,
+      // and b) the important thing to test is that datetime annotations are detected and their values are
+      //   transformed at all.
+      const dateTimeValue = '2024-01-01 12:30:00';
+      const dateTimeValueInUTCWithTimeZoneOffset = moment(dateTimeValue).format(); // UTC w/ tz offset
+
       const state: State = {
         ...nonEmptyStateForInitiatingUpload,
         template: {
@@ -163,7 +172,7 @@ describe("Upload selectors", () => {
         upload: getMockStateWithHistory({
           "/path/to.dot/image.tiff": {
             file: "/path/to.dot/image.tiff",
-            ['Seeded On']: ['2024-01-01 12:30:00'], // mockDateTimeAnnotation name
+            ['Seeded On']: [dateTimeValue], // mockDateTimeAnnotation name
           },
         }),
       };
@@ -173,7 +182,7 @@ describe("Upload selectors", () => {
             annotations: [
               {
                 annotationId: mockDateTimeAnnotation.annotationId,
-                values: ['2024-01-01T20:30:00.000Z'],
+                values: [dateTimeValueInUTCWithTimeZoneOffset],
               },
             ],
             templateId: mockMMSTemplate.templateId,

--- a/src/renderer/state/upload/test/selectors.test.ts
+++ b/src/renderer/state/upload/test/selectors.test.ts
@@ -150,6 +150,47 @@ describe("Upload selectors", () => {
       const actual = getUploadRequests(state);
       expect(actual).to.deep.equal(expectedPayload);
     });
+    it("Converts DateTime annotation values into properly-formatted ISO strings", () => {
+      const state: State = {
+        ...nonEmptyStateForInitiatingUpload,
+        template: {
+          ...nonEmptyStateForInitiatingUpload.template,
+          appliedTemplate: {
+            ...mockMMSTemplate,
+            annotations: [mockDateTimeAnnotation],
+          },
+        },
+        upload: getMockStateWithHistory({
+          "/path/to.dot/image.tiff": {
+            file: "/path/to.dot/image.tiff",
+            ['Seeded On']: ['2024-01-01 12:30:00'], // mockDateTimeAnnotation name
+          },
+        }),
+      };
+      const expectedPayload = [
+        {
+          customMetadata: {
+            annotations: [
+              {
+                annotationId: mockDateTimeAnnotation.annotationId,
+                values: ['2024-01-01T20:30:00.000Z'],
+              },
+            ],
+            templateId: mockMMSTemplate.templateId,
+          },
+          file: {
+            disposition: "tape",
+            fileType: FileType.IMAGE,
+            originalPath: "/path/to.dot/image.tiff",
+            shouldBeInArchive: true,
+            shouldBeInLocal: true,
+          },
+          microscopy: {},
+        },
+      ];
+      const actual = getUploadRequests(state);
+      expect(actual).to.deep.equal(expectedPayload);
+    });
     it("Interprets combined 'File Name (File ID)' FMS.File Lookup values into just File IDs", () => {
       const state: State = {
         ...nonEmptyStateForInitiatingUpload,

--- a/src/renderer/state/upload/test/selectors.test.ts
+++ b/src/renderer/state/upload/test/selectors.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { orderBy } from "lodash";
-
+import * as moment from "moment";
 
 import { AnnotationName } from "../../../constants";
 import { TemplateAnnotation } from "../../../services/metadata-management-service/types";


### PR DESCRIPTION
### Context
Emmanuel tried to upload a file using the "argolight optical control" template. His upload went through and the file showed up in FMS, but the File Upload App told him he had hit a 400 error and his annotations didn't get attached to his file.

### The Bug
[I recently fixed a bug where annotations with the "DateTime" type would not be captured correctly after user input and their values would not display](https://github.com/aics-int/aics-file-upload-app/pull/71). I guess I neglected to actually complete an upload using one of those annotations (lmao) and missed the fact that these annotations must not have been working for... some significant period of time? Ever? I'm not quite sure, but it's a little worrying.

When files are uploaded into FMS via the File Upload App, they're first uploaded via FSS, then their annotation info is filled out via an MMS endpoint as the final step.

The issue was that DateTime annotation values being sent to MMS were formatted like `yyyy-MM-dd HH:mm:ss` rather than `yyyy-MM-ddTHH:mm:ssZ` or `yyyy-MM-ddTHH:mm:ss+HH:mm`, AKA the ISO standard and ISO standard w/ a timezone offset respectively.

This PR updates that bit of code to make our request to MMS format DateTime annotations like that second expected format, the one with the timezone offset. E.g. `2024-01-01` -> `2024-01-01T00:00:00-08:00`

### Bug Thoughts
I vaguely recall not being sure of how date and datetime values were being stored in FMS / the custommetadata schema a long time ago... realistically, I think they should be stored in the ISO string + timezone offset format from the get-go. Like as soon as a user chooses the date and time they want to record, it should be tracked in the FUA app state as a datestring in that format. Not as a `Date` or `moment` object. Both of those should be able to be constructed from a datestring pretty easily anyways.

What we have even after this PR is a datepicker component that returns a `moment` that then gets stored in state as a `Date` which then gets transformed back into a `moment` only to get turned into a datestring :thinking: . It just seems weird and unstandardized, which can lead to confusion, which can lead to little bugs like this. But whatever - it's a minor issue.