### PR TITLE
Bugfix: Enable multifile boolean for templated uploads

### DIFF
--- a/src/renderer/state/test/mocks.ts
+++ b/src/renderer/state/test/mocks.ts
@@ -216,6 +216,20 @@ export const mockWellUpload: UploadStateBranch = {
     key: "/path/to/file3",
     [AnnotationName.WELL]: [1, 2, 3],
   },
+  "/path/to/file4.zarr": { // multifile
+    barcode: "1237",
+    ["Favorite Color"]: ["Red"],
+    file: "/path/to/file4.zarr",
+    key: "/path/to/file4.zarr",
+    [AnnotationName.WELL]: [1, 2, 3],
+  },
+  "/path/to/file5.sldy": { // multifile
+    barcode: "1238",
+    ["Favorite Color"]: ["Red"],
+    file: "/path/to/file5.sldy",
+    key: "/path/to/file5.sldy",
+    [AnnotationName.WELL]: [1, 2, 3],
+  },
 };
 
 export const mockTextAnnotation: TemplateAnnotation = {

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -197,9 +197,14 @@ const initiateUploadLogic = createLogic({
     let uploads: UploadJob[];
     try {
       uploads = await Promise.all(
-        requests.map((request) =>
-          fms.initiateUpload(request, user, { groupId })
-        )
+          requests.map((request) => {
+                const serviceFields = {
+                  groupId,
+                  multifile: determineIsMultifile(request.file.originalPath),
+                }
+                return fms.initiateUpload(request, user, serviceFields);
+              }
+          )
       );
     } catch (error) {
       dispatch(

--- a/src/renderer/state/upload/test/selectors.test.ts
+++ b/src/renderer/state/upload/test/selectors.test.ts
@@ -685,7 +685,9 @@ describe("Upload selectors", () => {
         template: mockTemplateStateBranchWithAppliedTemplate,
         upload: getMockStateWithHistory(mockWellUpload),
       });
-      expect(jobName).to.deep.equal(["file1", "file2", "file3"]);
+      expect(jobName).to.deep.equal(
+        ["file1", "file2", "file3", "file4.zarr", "file5.sldy"]
+      );
     });
   });
 


### PR DESCRIPTION
#### Context
There are two separate codepaths for uploads in the File Upload App - one for uploads without metadata, and one for uploads with metadata. Somehow, [in my initial PR](https://github.com/aics-int/aics-file-upload-app/pull/69), I didn't update the codepath where we correctly label an upload as a multifile upload in the request to FSS for uploads that have metadata. Whoops! That's kind of important.

This was an easy change though. Just check out the diff in `src/renderer/state/upload/logics.ts`. The rest are test updates.