### PR TITLE
(Tiny) [#74] Stop displaying selected date / datetime values as their UTC equivalents

### DIFF
--- a/src/renderer/containers/Table/DefaultCells/DisplayCell/index.tsx
+++ b/src/renderer/containers/Table/DefaultCells/DisplayCell/index.tsx
@@ -45,11 +45,11 @@ export const useDisplayValue = (value?: ColumnValue, type?: ColumnType) =>
         return value[0] ? "Yes" : "No";
       case ColumnType.DATE:
         return (value as Date[])
-          .map((d) => moment(d).utc().format("M/D/YYYY"))
+          .map((d) => moment(d).format("M/D/YYYY"))
           .join(", ");
       case ColumnType.DATETIME:
         return (value as Date[])
-          .map((d) => moment(d).utc().format("M/D/YYYY H:m:s"))
+          .map((d) => moment(d).format("M/D/YYYY H:m:s"))
           .join(", ");
       case ColumnType.DURATION: {
         const { days, hours, minutes, seconds } = value[0] as Duration;

--- a/src/renderer/containers/Table/Editors/DateEditor/index.tsx
+++ b/src/renderer/containers/Table/Editors/DateEditor/index.tsx
@@ -54,7 +54,7 @@ export default function DateEditor({
         className={styles.datePicker}
         showTime={column.type === ColumnType.DATETIME}
         placeholder="Add a Date"
-        value={value ? value.utc() : undefined}
+        value={value ? value : undefined}
         onChange={(selectedValue) => setValue(selectedValue ?? undefined)}
         renderExtraFooter={() => (
           <div className={styles.footer}>


### PR DESCRIPTION
### Context / Reasoning
For some reason, the date + datetime annotation value components will display a user's selected value as its UTC equivalent. In other words, someone will mark that a file was generated at 12:00 PM our time, and then the Upload App UI will display that value as if the user had selected 7 or 8 PM instead. Pretty weird.

I think this change is worthwhile because a) the current functionality could be confusing (it's confusing to me!), and b) it doesn't seem like the values saved in state ever get converted to UTC time anywhere else in the app anyways - it's only when they're displayed as values in the upload table. Seems non-sensical, or maybe the result of some decision from years past? We could have at least left a comment about it...