### PR TITLE
(Tiny) [FUA-68] Remove USE_MULTIFILE_ASSUMPTION env var check

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "compile-prod": "cross-env ELECTRON_WEBPACK_APP_LIMS_HOST=\"aics.corp.alleninstitute.org\" ELECTRON_WEBPACK_APP_LIMS_PORT=80 NODE_ENV=production yarn compile",
     "build-executable": "yarn compile && yarn electron-builder",
     "dist": "electron-builder -p always",
-    "test": "cross-env TS_NODE_PROJECT=tsconfig.commonjs.json TS_NODE_FILES=true NODE_ENV=production USE_MULTIFILE_ASSUMPTION=true mocha --exit src/**/test/*.{ts,tsx}",
+    "test": "cross-env TS_NODE_PROJECT=tsconfig.commonjs.json TS_NODE_FILES=true NODE_ENV=production mocha --exit src/**/test/*.{ts,tsx}",
     "postinstall": "electron-builder install-app-deps",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "madge": "madge --warning --circular --ts-config tsconfig.base.json --webpack-config webpack/webpack.render.additions.js --extensions js,jsx,ts,tsx  src/",

--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -81,15 +81,6 @@ export async function determineFilesFromNestedPaths(
  * @param filePath Path to the file
  */
 export function determineIsMultifile(filePath: string): boolean {
-  ///////////////////////////////////////////////////////////////////
-  // TODO - Remove this once multifile support is feature-complete //
-  //         Flip the boolean to "true" for testing                //
-  ///////////////////////////////////////////////////////////////////
-  const USE_MULTIFILE_ASSUMPTION = process.env.USE_MULTIFILE_ASSUMPTION !== undefined
-      ? process.env.USE_MULTIFILE_ASSUMPTION === 'true'
-      : false;
-  ///////////////////////////////////////////////////////////////////
-
   const multifileExtensions = ['.zarr', '.sldy'];
   const combinedExtensions = multifileExtensions.join('|');
 
@@ -99,7 +90,7 @@ export function determineIsMultifile(filePath: string): boolean {
 
   // If the regex matches it will return an array (truthy).
   // If the regex doesn't match it will return null (falsy).
-  return Boolean(filePath.match(matcher)) && USE_MULTIFILE_ASSUMPTION;
+  return Boolean(filePath.match(matcher))
 }
 
 /**


### PR DESCRIPTION
### Context
I knew FUA multifile support would involve multiple PRs, so I added an environment variable check to enable multifile features in testing and disable them in release builds.

This PR removes that check, effectively enabling multifile support in any new release builds going forward. Merging this PR should be the last step in #68 , and once it's merged and released we can officially claim that we support uploading multifiles.