### PR TITLE
Bugfix: Fix multifile upload retries, progress reporting

### DIFF
--- a/src/renderer/containers/App/handleUploadJobUpdates.ts
+++ b/src/renderer/containers/App/handleUploadJobUpdates.ts
@@ -98,15 +98,15 @@ export function handleUploadJobUpdates(job: JSSJob, dispatch: Dispatch<any>) {
       job.currentStage === UploadStatus.RETRY
     ) {
       dispatch(receiveFSSJobCompletionUpdate(fssJob));
-    }
-
-    // Otherwise, report progress
-    // TODO Multifile FSS jobs are currently identifiable by their service_fields.subfiles property,
-    //       but more ideally would just be labeled with something like "multifile: true".
-    if (fssJob.serviceFields?.subfiles) {
-      handleFSSMultifileJobUpdate(fssJob, dispatch);
     } else {
-      handleFSSJobUpdate(fssJob, dispatch);
+        // Otherwise, report progress
+        // TODO Multifile FSS jobs are currently identifiable by their service_fields.subfiles property,
+        //       but more ideally would just be labeled with something like "multifile: true".
+        if (fssJob.serviceFields?.subfiles) {
+            handleFSSMultifileJobUpdate(fssJob, dispatch);
+        } else {
+            handleFSSJobUpdate(fssJob, dispatch);
+        }
     }
   } else if (job.serviceFields?.type === "upload") {
     // Otherwise separate user's other jobs from ones created by this app

--- a/src/renderer/services/file-management-system/index.ts
+++ b/src/renderer/services/file-management-system/index.ts
@@ -5,7 +5,7 @@ import { uniq } from "lodash";
 import * as uuid from "uuid";
 
 import { Step } from "../../containers/Table/CustomCells/StatusCell/Step";
-import { extensionToFileTypeMap, FileType, getDirectorySize } from "../../util";
+import { determineIsMultifile, extensionToFileTypeMap, FileType, getDirectorySize} from "../../util";
 import FileStorageService, {
   UploadStatus,
   UploadStatusResponse,
@@ -119,7 +119,7 @@ export default class FileManagementSystem {
     // Grab file details
     const source = upload.serviceFields.files[0]?.file.originalPath;
     const fileName = path.basename(source);
-    const isMultifile = upload.serviceFields.multifile || false;
+    const isMultifile = determineIsMultifile(upload.jobName);
 
     const sourceStat = await fs.promises.stat(source);
     let { size: fileSize } = sourceStat;


### PR DESCRIPTION
#### Context
I recently tried uploading a `.sldy` sub-directory, and it seemed to be broken on two fronts:

1. If I closed the app mid-upload and then re-opened it, progress reporting wouldn't start up again (progress for the file would say `Step 1 of 3: 0%`)
2. If I didn't close the app and just let the upload run to completion, it would seem to get stuck at `Step 3 of 3: 99%`.

#### Changes
Problem 1 seemed to be cropping up because files wouldn't properly be labeled as multifiles when re-registered. This would seem to be a result of the `service_fields` property for a resumed job not getting updated correctly somewhere in our retry code.

Problem 2 seemed to be a result of a control flow mistake in the `handleUploadJobUpdates` module. The module would dispatch `receiveFSSJobCompletionUpdate()` when a job was completed (good), but then if the `serviceFields.subfiles` property was still present, it would move into the block where it labels the progress percentage in step 3 of 3 (bad - it should be "done").