### PR TITLE
[FUA-85] Load fonts correctly; Remove url-loader dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "source-map-support": "~0.5.21",
         "ts-import-plugin": "~2.0.0",
         "ts-node": "~10.4.0",
-        "url-loader": "^4.0.0",
         "uuid": "~8.3.0"
       },
       "devDependencies": {
@@ -18284,32 +18283,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-loader": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
-      "integrity": "sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "mime-types": "^2.1.27",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "file-loader": "*",
-        "webpack": "^4.0.0 || ^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "file-loader": {
-          "optional": true
-        }
       }
     },
     "node_modules/url-parse": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "source-map-support": "~0.5.21",
     "ts-import-plugin": "~2.0.0",
     "ts-node": "~10.4.0",
-    "url-loader": "^4.0.0",
     "uuid": "~8.3.0"
   },
   "devDependencies": {

--- a/webpack/webpack.main.config.js
+++ b/webpack/webpack.main.config.js
@@ -84,14 +84,6 @@ module.exports = ({ production }) => {
           },
             {test: /\.node$/, use: 'node-loader'},
             {
-              test: /\.(png|jpg|gif)$/,
-              use:
-                [{
-                  loader: 'url-loader',
-                  options: {limit: 10485760, name: 'imgs/[name]--[folder].[ext]'}
-                }]
-            },
-            {
               test: /\.tsx?$/,
               exclude: /node_modules/,
               use:

--- a/webpack/webpack.renderer.config.js
+++ b/webpack/webpack.renderer.config.js
@@ -132,19 +132,6 @@ module.exports = ({ production })  => {
                   'sass-loader']
             },
             {
-              test: /\.(png|jpe?g|gif)(\?.*)?$/,
-              use:
-                {
-                  loader: 'url-loader',
-                  options: {limit: 10240, name: 'imgs/[name]--[folder].[ext]'}
-                }
-            },
-            {
-              test: /\.(mp4|webm|ogg|mp3|wav|flac|aac)(\?.*)?$/,
-              loader: 'url-loader',
-              options: {limit: 10240, name: 'media/[name]--[folder].[ext]'}
-            },
-            {
               test: /\.ttf/,
               type: 'asset/resource'
             },

--- a/webpack/webpack.renderer.config.js
+++ b/webpack/webpack.renderer.config.js
@@ -145,12 +145,8 @@ module.exports = ({ production })  => {
               options: {limit: 10240, name: 'media/[name]--[folder].[ext]'}
             },
             {
-              test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
-              use:
-                {
-                  loader: 'url-loader',
-                  options: {limit: 10240, name: 'fonts/[name]--[folder].[ext]'}
-                }
+              test: /\.ttf/,
+              type: 'asset/resource'
             },
             {test: /\.(html)$/, use: {loader: 'html-loader'}},
             {


### PR DESCRIPTION
### Changes
* Fixes #85 
* Removes now-unnecessary `url-loader` dependency

Not sure _exactly_ why fonts weren't loading correctly following the switch I made to webpack v5, but v5 [has this cool new feature that simplifies asset loading and fixes this issue for us](https://webpack.js.org/guides/asset-modules/). It also means we don't need `url-loader` anymore - builds seem fine without it!


Compare this new pic:
<img width="244" alt="image" src="https://github.com/aics-int/aics-file-upload-app/assets/65628854/828ffd13-058a-4679-b165-71bc747c3993">

To the pic from the ticket:
![image](https://github.com/aics-int/aics-file-upload-app/assets/65628854/13f9c199-ec06-4aee-ad8a-95c5eb411437)
