### PR TITLE
Version 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-upload-app",
-  "version": "3.2.2-snapshot.2",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-upload-app",
-      "version": "3.2.2-snapshot.2",
+      "version": "3.3.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-upload-app",
-  "version": "3.2.2-snapshot.1",
+  "version": "3.2.2-snapshot.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-upload-app",
-      "version": "3.2.2-snapshot.1",
+      "version": "3.2.2-snapshot.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "22.x",
     "npm": "10.x"
   },
-  "version": "3.2.2-snapshot.2",
+  "version": "3.3.0",
   "build": {
     "appId": "org.aics.alleninstitute.fileupload",
     "artifactName": "file-upload-app-${version}.${ext}",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "22.x",
     "npm": "10.x"
   },
-  "version": "3.2.2-snapshot.1",
+  "version": "3.2.2-snapshot.2",
   "build": {
     "appId": "org.aics.alleninstitute.fileupload",
     "artifactName": "file-upload-app-${version}.${ext}",


### PR DESCRIPTION
Tag is already pushed and artifacts are already in S3 + [available on the download page](https://aics-int.github.io/aics-file-upload-app/). This PR just updates the version number in `package.json` and `package-lock.json`.