### PR TITLE
feature/multifile-id-job-updates

### DIFF
--- a/src/renderer/containers/App/handleUploadJobUpdates.ts
+++ b/src/renderer/containers/App/handleUploadJobUpdates.ts
@@ -73,6 +73,7 @@ function handleFSSMultifileJobUpdate(job: FSSUpload, dispatch: Dispatch<any>) {
       })
     );
   }
+  // TODO?: Maybe raise error here if there is no subfiles?
 }
 
 /**
@@ -100,9 +101,7 @@ export function handleUploadJobUpdates(job: JSSJob, dispatch: Dispatch<any>) {
       dispatch(receiveFSSJobCompletionUpdate(fssJob));
     } else {
         // Otherwise, report progress
-        // TODO Multifile FSS jobs are currently identifiable by their service_fields.subfiles property,
-        //       but more ideally would just be labeled with something like "multifile: true".
-        if (fssJob.serviceFields?.subfiles) {
+        if (fssJob.serviceFields?.multifile) {
             handleFSSMultifileJobUpdate(fssJob, dispatch);
         } else {
             handleFSSJobUpdate(fssJob, dispatch);

--- a/src/renderer/containers/App/test/App.test.ts
+++ b/src/renderer/containers/App/test/App.test.ts
@@ -77,6 +77,7 @@ describe("App", () => {
             user: "fakeuser",
             status: JSSJobStatus.WORKING,
             serviceFields: {
+                multifile: true,
                 fileSize: 100,
                 subfiles: {
                     'fileid1': 10,

--- a/src/renderer/services/file-storage-service/index.ts
+++ b/src/renderer/services/file-storage-service/index.ts
@@ -15,6 +15,7 @@ export interface FSSUpload extends JSSJob {
     postUploadMd5?: number;
     fileSize?: number;
     currentFileSize?: number;
+    multifile?: boolean;
     subfiles?: { [fileId: string]: number }; // mapping of subfile IDs to their respective # of bytes uploaded
   };
 }


### PR DESCRIPTION
### Description 
The purpose of this PR is to resolve [TODO ](https://github.com/aics-int/aics-file-upload-app/blob/main/src/renderer/containers/App/handleUploadJobUpdates.ts#L103-L106) and use `multifile` service field in place of existing logic.