### PR TITLE
User-Interface/upload-status-clarity

### DIFF
--- a/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
@@ -48,11 +48,10 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
 
   let content: React.ReactNode;
   if (JSSJobStatus.SUCCEEDED === props.value) {
-    
     // Though an upload has a successful status there may be post upload
     // processes that have yet to complete which would make this upload
     // effectively incomplete
-    const etlProcess = 
+    const etlProcess =
       props.row.original.serviceFields?.postUploadProcessing?.etl;
 
     if (etlProcess?.status === JSSJobStatus.FAILED) {
@@ -85,6 +84,7 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
     const totalForStep = getBytesDisplay(totalBytes);
     let progressForStep = 0;
     if (bytesUploaded && totalBytes) {
+      // Uploading bytes, and progress has been made.
       progressForStep = Math.floor((bytesUploaded / totalBytes) * 100);
     }
 
@@ -117,4 +117,3 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
     </Tooltip>
   );
 }
-

--- a/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleFilled, CloseCircleFilled, QuestionCircleFilled } from "@ant-design/icons";
+import { CheckCircleFilled, CloseCircleFilled } from "@ant-design/icons";
 import { Progress, Tooltip } from "antd";
 import * as React from "react";
 import { CellProps } from "react-table";
@@ -48,42 +48,31 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
 
   let content: React.ReactNode;
   if (JSSJobStatus.SUCCEEDED === props.value) {
+    
     // Though an upload has a successful status there may be post upload
     // processes that have yet to complete which would make this upload
     // effectively incomplete
-    const etlProcess =
+    const etlProcess = 
       props.row.original.serviceFields?.postUploadProcessing?.etl;
-    if (etlProcess?.status === JSSJobStatus.SUCCEEDED) {
-      content = (
-        <CheckCircleFilled className={styles.success} />
-      );
-    } else {
-      if (
-        etlProcess?.status ===
-        JSSJobStatus.FAILED
-      ) {
-        tooltip = `${tooltip} - File has been successfully uploaded to FMS, but may not be viewable in the File Upload App. Attempt to make it visible in the FMS Explorer resulted in the following error: ${etlProcess?.status_detail}`;
-      } else {
-        tooltip = `${tooltip} - File has been successfully uploaded; working on making it visible in the File Upload App if it isn't already`;
-      }
 
-      content = (
-        <QuestionCircleFilled
-          className={styles.success}
-        />
-      );
+    if (etlProcess?.status === JSSJobStatus.FAILED) {
+      tooltip = `${tooltip} - File has been successfully uploaded to FMS, but may not be viewable in the File Upload App. Attempt to make it visible in the FMS Explorer resulted in the following error: ${etlProcess?.status_detail}`;
+    } else if (etlProcess?.status !== JSSJobStatus.SUCCEEDED) {
+      tooltip = `${tooltip} - File has been successfully uploaded; working on making it visible in the File Upload App if it isn't already`;
     }
+
+    const iconColor =
+      etlProcess?.status === JSSJobStatus.FAILED ||
+      etlProcess?.status !== JSSJobStatus.SUCCEEDED
+        ? "#CEE9DF"
+        : undefined;
+
+    content = <CheckCircleFilled style={{ color: iconColor }} className={styles.success} />;
   } else if (JSSJobStatus.FAILED === props.value) {
-    content = (
-      <CloseCircleFilled className={styles.failed} />
-    );
+    content = <CloseCircleFilled className={styles.failed} />;
   } else if (JSSJobStatus.UNRECOVERABLE === props.value) {
-    content = (
-      <CloseCircleFilled
-        className={styles.unrecoverable}
-      />
-    ); 
-    // TODO SWE-875 update progress for pre and post upload 
+    content = <CloseCircleFilled className={styles.unrecoverable} />;
+    // TODO SWE-875 update progress for pre and post upload
     // based on props.row.original.progress.status=[PRE | UPLOAD | POST]
   } else {
     const {
@@ -96,7 +85,6 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
     const totalForStep = getBytesDisplay(totalBytes);
     let progressForStep = 0;
     if (bytesUploaded && totalBytes) {
-      // Uploading bytes, and progress has been made.
       progressForStep = Math.floor((bytesUploaded / totalBytes) * 100);
     }
 
@@ -129,3 +117,4 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
     </Tooltip>
   );
 }
+

--- a/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/index.tsx
@@ -48,25 +48,14 @@ export default function StatusCell(props: CellProps<UploadSummaryTableRow>) {
 
   let content: React.ReactNode;
   if (JSSJobStatus.SUCCEEDED === props.value) {
-    // Though an upload has a successful status there may be post upload
-    // processes that have yet to complete which would make this upload
-    // effectively incomplete
-    const etlProcess =
-      props.row.original.serviceFields?.postUploadProcessing?.etl;
+    const etlProcess = props.row.original.serviceFields?.postUploadProcessing?.etl;
 
-    if (etlProcess?.status === JSSJobStatus.FAILED) {
-      tooltip = `${tooltip} - File has been successfully uploaded to FMS, but may not be viewable in the File Upload App. Attempt to make it visible in the FMS Explorer resulted in the following error: ${etlProcess?.status_detail}`;
-    } else if (etlProcess?.status !== JSSJobStatus.SUCCEEDED) {
-      tooltip = `${tooltip} - File has been successfully uploaded; working on making it visible in the File Upload App if it isn't already`;
-    }
+    const isConditionalSuccess = etlProcess?.status !== JSSJobStatus.SUCCEEDED;
+    tooltip = isConditionalSuccess
+        ? `${tooltip} - File successfully uploaded to FMS. It will be searchable once all metadata has been appended, which is happening now in the background.`
+        : tooltip;
 
-    const iconColor =
-      etlProcess?.status === JSSJobStatus.FAILED ||
-      etlProcess?.status !== JSSJobStatus.SUCCEEDED
-        ? "#CEE9DF"
-        : undefined;
-
-    content = <CheckCircleFilled style={{ color: iconColor }} className={styles.success} />;
+    content = <CheckCircleFilled className={`${styles.success} ${isConditionalSuccess ? styles['success-conditional'] : ''}`} />;
   } else if (JSSJobStatus.FAILED === props.value) {
     content = <CloseCircleFilled className={styles.failed} />;
   } else if (JSSJobStatus.UNRECOVERABLE === props.value) {

--- a/src/renderer/containers/Table/CustomCells/StatusCell/styles.pcss
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/styles.pcss
@@ -23,6 +23,10 @@
     margin: auto;
 }
 
+.success-conditional {
+    color: #CEE9DF;
+}
+
 .active-info > p {
     margin: 0;
 }

--- a/src/renderer/containers/Table/CustomCells/StatusCell/test/StatusCell.test.tsx
+++ b/src/renderer/containers/Table/CustomCells/StatusCell/test/StatusCell.test.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleFilled, CloseCircleFilled, QuestionCircleFilled } from "@ant-design/icons";
+import { CheckCircleFilled, CloseCircleFilled } from "@ant-design/icons";
 import { Progress, Tooltip } from "antd";
 import { expect } from "chai";
 import { mount } from "enzyme";
@@ -61,7 +61,7 @@ describe("<StatusCell />", () => {
     );
 
     // Assert
-    expect(wrapper.exists(QuestionCircleFilled)).to.be.true;
+    expect(wrapper.exists(CheckCircleFilled)).to.be.true;
   });
 
   it("shows step 1 when in first step of upload", () => {


### PR DESCRIPTION
### Description 
Attempts to resolve #111 After upload, sometimes users are presented with a green circle containing a question mark as a status. Users have no idea what this means. We decided to move the question mark to a check mark and change the color. Following this spec:
![Screenshot 2024-10-29 at 2 08 08 PM](https://github.com/user-attachments/assets/4d33914f-b014-4e43-8a6c-a7d43132d069)
