### PR TITLE
(Small) [FUA-92] Change default environment to production

### DIFF
--- a/src/renderer/services/http-cache-client/test/http-cache-client.test.ts
+++ b/src/renderer/services/http-cache-client/test/http-cache-client.test.ts
@@ -120,7 +120,7 @@ describe("HttpCacheClient", () => {
     await httpCacheClient.get(url);
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(httpClient.get).to.have.been.calledOnceWith(
-      "http://localhost:8080/foo"
+      "http://aics.corp.alleninstitute.org:80/foo"
     );
   });
 });

--- a/src/renderer/state/setting/test/logics.test.ts
+++ b/src/renderer/state/setting/test/logics.test.ts
@@ -33,7 +33,7 @@ import {
 } from "../selectors";
 
 describe("Setting logics", () => {
-  const localhost = "localhost";
+  const productionHost = "aics.corp.alleninstitute.org";
   const stagingHost = "staging";
   let labkeyClient: SinonStubbedInstance<LabkeyClient>;
   let storage: SinonStubbedInstance<EnvironmentAwareStorage>;
@@ -67,7 +67,7 @@ describe("Setting logics", () => {
 
     it("updates settings if data persisted correctly", () => {
       // before
-      expect(getLimsHost(store.getState())).to.equal(localhost);
+      expect(getLimsHost(store.getState())).to.equal(productionHost);
 
       // apply
       store.dispatch(updateSettings({ limsHost: stagingHost }));
@@ -122,7 +122,7 @@ describe("Setting logics", () => {
       ]);
 
       // before
-      expect(getLimsHost(store.getState())).to.equal(localhost);
+      expect(getLimsHost(store.getState())).to.equal(productionHost);
 
       // apply
       store.dispatch(updateSettings({ limsHost: stagingHost }));
@@ -234,7 +234,7 @@ describe("Setting logics", () => {
       const { logicMiddleware, store } = createMockReduxStore(mockState);
 
       // before
-      expect(getLimsHost(store.getState())).to.equal(localhost);
+      expect(getLimsHost(store.getState())).to.equal(productionHost);
       expect(getTemplateId(store.getState())).to.be.undefined;
 
       // apply
@@ -256,7 +256,7 @@ describe("Setting logics", () => {
       await logicMiddleware.whenComplete();
 
       // after
-      expect(getLimsHost(store.getState())).to.equal(localhost);
+      expect(getLimsHost(store.getState())).to.equal(productionHost);
       expect(getAlert(store.getState())).to.not.be.undefined;
     });
   });

--- a/src/renderer/state/setting/test/selectors.test.ts
+++ b/src/renderer/state/setting/test/selectors.test.ts
@@ -7,7 +7,7 @@ describe("Settings selectors", () => {
   describe("getLimsUrl", () => {
     it("constructs lims url from settings", () => {
       const url = getLimsUrl(mockState);
-      expect(url).to.equal("http://localhost:8080");
+      expect(url).to.equal("http://aics.corp.alleninstitute.org:80");
     });
   });
 });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -53,8 +53,8 @@ export enum RendererProcessEvents {
 
 // Default host/port/protocol for LIMS
 export const LIMS_HOST =
-  process.env.APP_LIMS_HOST || "localhost";
-export const LIMS_PORT = process.env.APP_LIMS_PORT || "8080";
+  process.env.APP_LIMS_HOST || "aics.corp.alleninstitute.org";
+export const LIMS_PORT = process.env.APP_LIMS_PORT || "80";
 export const LIMS_PROTOCOL =
   process.env.APP_LIMS_PROTOCOL || "http";
 


### PR DESCRIPTION
closes #92 

### Description
* Changes the default target environment to `aics.corp.alleninstitute.org:80` instead of `localhost:8080`.

### Context
Without this, new Upload App users will default to looking at an error message saying `Failed to retrieve metadata: Request failed with status code 404`. Then the loading spinner on the landing page will spin forever. Won't make a great impression if we anticipate increased FUA usage following the move to cloud-first FMS!

### Recreating

See `electron-store` NPM page here:
https://www.npmjs.com/package/electron-store/v/5.2.0

The package we use for storing user configs places those config files under `app.getPath('userData')`. For MacOS, this comes out to `/Users/<your user>/Library/Application Support/file-upload-app`. Navigate to that path and delete `config.json` to reset your File Upload App config. Doing so before this branch has been merged will prove that the app defaults to the `localhost` environment setting, at least when launching in dev mode.

### Reviewing
One main file here, then just updated tests.
* [src/shared/constants.ts](https://github.com/aics-int/aics-file-upload-app/compare/feature/FUA-92_default_to_production?expand=1#diff-84451d0e7a53cf99f9eb786c5cebf4a96c2447f149c1ea0eece1f42c445b8eef)