### PR TITLE
Bugfix/128 cloud only upload crash

### DIFF
--- a/src/renderer/state/route/logics.ts
+++ b/src/renderer/state/route/logics.ts
@@ -298,7 +298,7 @@ const viewUploadsLogic = createLogic({
         ...labkeyFileMetadata,
         customMetadata,
         file: {
-          originalPath: labkeyFileMetadata.localFilePath as string,
+          originalPath: labkeyFileMetadata.publicFilePath as string,
           fileType: labkeyFileMetadata.fileType,
         },
       }));

--- a/src/renderer/state/route/test/logics.test.ts
+++ b/src/renderer/state/route/test/logics.test.ts
@@ -152,7 +152,8 @@ describe("Route logics", () => {
       filename: "name",
       fileSize: 1,
       fileType: "image",
-      localFilePath: "/localFilePath",
+      localFilePath: "",
+      publicFilePath: "s3path/name",
       modified: "",
       modifiedBy: "foo",
     };
@@ -376,8 +377,8 @@ describe("Route logics", () => {
       expect(getPage(state)).to.equal(Page.UploadWithTemplate);
       expect(getView(state)).to.equal(Page.UploadWithTemplate);
       expect(getUpload(state)).to.deep.equal({
-        [fileMetadata.localFilePath || ""]: {
-          file: fileMetadata.localFilePath,
+        [fileMetadata.publicFilePath || ""]: {
+          file: fileMetadata.publicFilePath,
           fileId: fileMetadata.fileId,
           "Favorite Color": ["Blue", "Green"],
           [AnnotationName.WELL]: ["A1", "B6"],


### PR DESCRIPTION
# Purpose
Allow cloud-only uploads to have their metadata edited

Closes #128 

# Changes
Use `fms.file.publicfilepath` instead of `fms.file.localfilepath`. The error that was triggered is only using this path to get the filename, but I am uncertain if other parts of the code use the full path.

# Testing
* Updated unit test first to match the new contract: with just the test changed, the test fails. Then the second commit makes the test pass again.
* Manually tested by editing the metadata of a cloud-only upload in staging.