### PR TITLE
(Tiny) [FUA-141] Fix unsightly scrollbars.

### DIFF
--- a/src/renderer/containers/App/styles.pcss
+++ b/src/renderer/containers/App/styles.pcss
@@ -13,7 +13,7 @@
 :global(html), :global(body), :global(main), :global(#app) {
   width: 100%;
   height: 100%;
-  overflow: scroll;
+  overflow: auto;
 }
 
 :global(.rdg-editor-container) {
@@ -30,7 +30,7 @@
   flex-direction: column;
   font-size: 14px;
   font-family: 'Nunito', sans-serif;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .main-content {
@@ -47,6 +47,6 @@
 :global(.ant-message-custom-content) {
   line-height: 24px;
   max-height: calc(24px * 5);
-  overflow: scroll;
+  overflow: auto;
 }
 

--- a/src/renderer/containers/UploadSelectionPage/styles.pcss
+++ b/src/renderer/containers/UploadSelectionPage/styles.pcss
@@ -23,7 +23,7 @@ h1 {
   display: block;
   margin-bottom: 100px;
   max-width: calc(100% - var(--navigation-bar-width));
-  overflow: scroll;
+  overflow: auto;
   position: relative;
   width: 100vw;
 }


### PR DESCRIPTION
Closes #141 .

### Context / Change
See the ticket for pictures. I noticed some less-than-beautiful scrollbars when I ran the app on my Windows setup. Turns out we had some global CSS properties that were forcing the scrollbars to render even when there was nothing to scroll to. And they made the app look not-great!

> `auto`
> Unlike scroll, user agents display scroll bars only if the content is overflowing