### PR TITLE
(Tiny)[FUA-150] Change "Multifile" to "Chunked File"

### DIFF
--- a/src/renderer/containers/UploadSelectionPage/UploadTypeSelector/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/UploadTypeSelector/index.tsx
@@ -37,7 +37,7 @@ export default function UploadTypeSelector() {
                     <div className={styles.radioButtonContent}>
                         <FileOutlined className={styles.radioButtonIcon} />
                         <div className={styles.radioButtonText}>
-                            <span className={styles.radioButtonTitle}>File</span>
+                            <span className={styles.radioButtonTitle}>{UploadType.File}</span>
                             <br />
                             <span className={styles.radioButtonHelpText}>A single file such as a .czi, .ome.tiff, .csv, etc.</span>
                         </div>
@@ -51,9 +51,9 @@ export default function UploadTypeSelector() {
                     <div className={styles.radioButtonContent}>
                         <CopyOutlined className={styles.radioButtonIcon} />
                         <div className={styles.radioButtonText}>
-                            <span className={styles.radioButtonTitle}>Multifile</span>
+                            <span className={styles.radioButtonTitle}>{UploadType.Multifile}</span>
                             <br />
-                            <span className={styles.radioButtonHelpText}>Advanced file types such as .zarr, .sldy, etc.</span>
+                            <span className={styles.radioButtonHelpText}>Distributed file formats such as .zarr, .sldy, etc.</span>
                         </div>
                     </div>
                 </Radio.Button>

--- a/src/renderer/containers/UploadSelectionPage/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/index.tsx
@@ -40,7 +40,7 @@ export default function UploadSelectionPage() {
   if (uploadType === UploadType.Multifile) {
     openDialogOptions = {
       properties: ["openDirectory", "multiSelections"],
-      title: "Browse for multifiles",
+      title: "Browse for chunked files",
     }
   }
 

--- a/src/renderer/containers/UploadSelectionPage/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/index.tsx
@@ -35,12 +35,12 @@ export default function UploadSelectionPage() {
   // Default to "File" option
   let openDialogOptions: OpenDialogOptions = {
     properties: ["openFile", "multiSelections"],
-    title: "Browse for files",
+    title: `Browse for ${UploadType.File}s`,
   }
   if (uploadType === UploadType.Multifile) {
     openDialogOptions = {
       properties: ["openDirectory", "multiSelections"],
-      title: "Browse for chunked files",
+      title: `Browse for ${UploadType.Multifile}s`,
     }
   }
 

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -34,5 +34,6 @@ export interface SelectUploadTypeAction {
 
 export enum UploadType {
   File = 'File',
-  Multifile = 'Multifile'
+  // We use the term "Chunked File" in the UI, "Multifile" in FSS.
+  Multifile = 'Chunked File',
 }


### PR DESCRIPTION
closes #150 

@TravisKroeker spoke with leadership, and apparently "chunked file" is the new term they landed on for what we now call "multifile". I'm not a huge fan of it personally... but it's not my decision! There are only a handful of places in the UI where we actually use the term, so the idea with this PR is that we can just change the appropriate `enum UploadType` value and use that value for referring to next generation distributed file formats in the UI wherever we do.

In the rest of the code it's still just "multifile" for now.