### PR TITLE
(Small)[FUA-151] Update Drag-and-Drop UI

### DIFF
--- a/src/renderer/containers/UploadSelectionPage/DragAndDropPrompt/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/DragAndDropPrompt/index.tsx
@@ -1,11 +1,12 @@
 import { UploadOutlined } from '@ant-design/icons';
-import { Button } from 'antd';
 import { OpenDialogOptions, ipcRenderer } from "electron";
 import { isEmpty } from "lodash";
 import React from 'react';
 
 import { RendererProcessEvents } from '../../../../shared/constants';
 import { UploadType } from '../../../types';
+import { useSelector } from 'react-redux';
+import { getUploadType } from '../../../state/selection/selectors';
 
 const styles = require("./styles.pcss");
 
@@ -16,6 +17,7 @@ interface DragAndDropPromptProps {
 }
 
 export default function DragAndDropPrompt(props: DragAndDropPromptProps) {
+    const uploadType = useSelector(getUploadType);
 
     const onBrowse = async () => {
         const filePaths = await ipcRenderer.invoke(
@@ -29,24 +31,14 @@ export default function DragAndDropPrompt(props: DragAndDropPromptProps) {
         }
     };
 
-    let helpText: string | null = null;
-    if (props.uploadType) {
-      helpText = props.uploadType === UploadType.File
-        ? "Accepted file formats include: .czi, .tiff, .ome.tiff, .csv, ..."
-        : "Accepted file formats include: .zarr, .sldy, ..."
-    }
-
     return (
         <div className={styles.content}>
-          <h1 className={styles.header}>Select file(s) to upload</h1>
+          <h1 className={styles.header}>Select {uploadType}(s) to upload</h1>
           <div className={styles.dropZone} onClick={onBrowse}>
             <UploadOutlined className={styles.uploadIcon} />
             <div>Drag&nbsp;and&nbsp;Drop</div>
-            <div className={styles.dropZoneHelpText}>{helpText}</div>
+            <div className={styles.dropZoneHelpText}>or click to browse file paths</div>
           </div>
-          <Button className={styles.dropZoneBrowseButton} disabled={!props.openDialogOptions} onClick={onBrowse}>
-            Browse Files
-          </Button>
         </div>
     );
 }

--- a/src/renderer/containers/UploadSelectionPage/DragAndDropPrompt/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/DragAndDropPrompt/index.tsx
@@ -2,11 +2,11 @@ import { UploadOutlined } from '@ant-design/icons';
 import { OpenDialogOptions, ipcRenderer } from "electron";
 import { isEmpty } from "lodash";
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 import { RendererProcessEvents } from '../../../../shared/constants';
-import { UploadType } from '../../../types';
-import { useSelector } from 'react-redux';
 import { getUploadType } from '../../../state/selection/selectors';
+import { UploadType } from '../../../types';
 
 const styles = require("./styles.pcss");
 

--- a/src/renderer/containers/UploadSelectionPage/DragAndDropPrompt/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/DragAndDropPrompt/index.tsx
@@ -37,7 +37,7 @@ export default function DragAndDropPrompt(props: DragAndDropPromptProps) {
           <div className={styles.dropZone} onClick={onBrowse}>
             <UploadOutlined className={styles.uploadIcon} />
             <div>Drag&nbsp;and&nbsp;Drop</div>
-            <div className={styles.dropZoneHelpText}>or click to browse file paths</div>
+            <div className={styles.dropZoneHelpText}>or click to browse files</div>
           </div>
         </div>
     );

--- a/src/renderer/containers/UploadSelectionPage/DragAndDropPrompt/styles.pcss
+++ b/src/renderer/containers/UploadSelectionPage/DragAndDropPrompt/styles.pcss
@@ -11,13 +11,13 @@
 
 .drop-zone {
   border: 2px dashed black;
-  border-color: var(--grey);
+  border-color: #595959;
   border-radius: 25px;
 
   font-size: 18px;
 
-  padding-bottom: 80px;
-  padding-top: 80px;
+  padding-bottom: 70px;
+  padding-top: 70px;
 
   text-align: center;
   width: 100%;
@@ -26,7 +26,7 @@
   transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
-.drop-zone:hover {
+.drop-zone:hover, .drop-zone:hover .drop-zone-help-text {
     border-color: var(--brand-primary);
     color: var(--brand-primary);
     cursor: pointer;
@@ -38,7 +38,9 @@
 }
 
 .drop-zone-help-text {
-  font-size: 0.6em;
+  color: #595959;
+  font-size: 0.8em;
+  transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
 .upload-icon {


### PR DESCRIPTION
closes #151 

Some minor improvements to the drag-and-drop indicator on the Upload Selection page.

* Removed the "Browse File Paths" button, since the box is already a button that does the same thing.
* Updated help text to be less redundant with "Upload Type" help text above, instead now suggests you can click on the drag and drop zone.
* Header now reflects selected UploadType.
* Made the zone slightly shorter so that the "selected files" list below will be more visible once it's rendered.
* Small color changes to help text, border.

Before:
<img width="1015" alt="DnD-before" src="https://github.com/user-attachments/assets/5e91166e-aa1e-42b4-bcbf-599a728c8f1d" />

After:
<img width="1022" alt="Dnd-after" src="https://github.com/user-attachments/assets/56dcd764-2e6f-4903-be0e-2a7059589058" />

Hover:
<img width="1012" alt="dnd-after-hover" src="https://github.com/user-attachments/assets/25612963-c750-4983-a265-bf3b9ad61dfe" />

