### PR TITLE
[FUA-156] Add additional help text under "Upload Type" selector

### DIFF
--- a/src/renderer/containers/UploadSelectionPage/UploadTypeSelector/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/UploadTypeSelector/index.tsx
@@ -19,6 +19,12 @@ export default function UploadTypeSelector() {
         dispatch(selectUploadType(e.target.value));
     }
 
+    // Help text below the radio group. Defaults to the text for UploadType.File
+    let additionalHelpText = `Select one or more standalone files. Attempting to select ${UploadType.Multifile}s or folders will result in an error.`
+    if (uploadType === UploadType.Multifile) {
+        additionalHelpText = `Select one or more ${UploadType.Multifile} folders. Each folder in your selection will be uploaded as a single FMS record.`
+    }
+
     return (
         <div>
             <h1>
@@ -58,6 +64,11 @@ export default function UploadTypeSelector() {
                     </div>
                 </Radio.Button>
             </Radio.Group>
+            {uploadType !== null &&
+                <div className={styles.additionalHelpText}>
+                    {additionalHelpText}
+                </div>
+            }
         </div>
     )
 }

--- a/src/renderer/containers/UploadSelectionPage/UploadTypeSelector/styles.pcss
+++ b/src/renderer/containers/UploadSelectionPage/UploadTypeSelector/styles.pcss
@@ -1,3 +1,8 @@
+.additional-help-text {
+  padding-left: 5px;
+  padding-top: 5px;
+}
+
 .radio-button {
   align-items: center;
   display: flex;


### PR DESCRIPTION
closes #156

While the "Upload Type" radio buttons have help text on them already, Travis and I figured that the selection is still complicated enough to warrant additional hints as to what they do. This PR adds more help text that changes depending on the user's selected UploadType.

Before:
<img width="1011" alt="upload-type-before" src="https://github.com/user-attachments/assets/eab70f2e-e574-4123-91c0-b7f454faa924" />


After:

https://github.com/user-attachments/assets/43478db6-ad5b-406d-8a86-423059cb2757


