### PR TITLE
[FUA-155] Move and restyle "Add More Files" button on "Add Metadata" page

### DIFF
--- a/src/renderer/containers/AddMetadataPage/AddMetadataPageFooter/index.tsx
+++ b/src/renderer/containers/AddMetadataPage/AddMetadataPageFooter/index.tsx
@@ -4,9 +4,8 @@ import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import PageFooter from "../../../components/PageFooter";
-import { closeUpload, selectPage } from "../../../state/route/actions";
+import { closeUpload } from "../../../state/route/actions";
 import { getSelectedUploads, getShouldBeInLocal } from "../../../state/selection/selectors";
-import { Page } from "../../../state/types";
 import {
   initiateUpload,
   submitFileMetadataUpdate,
@@ -64,15 +63,7 @@ export default function AddMetadataPageFooter(props: Props) {
               onClick={onCancel}
           >
               Cancel Upload
-          </Button>
-      {!selectedUploads.length && // If we're adding new files, not editing ones that have been uploaded.
-        <Button
-          className={styles.cancelButton}
-          onClick={() => dispatch(selectPage(Page.UploadWithTemplate))}
-        >
-          Add More Files
-        </Button>
-      }
+      </Button>
       <Button
         type="primary"
         onClick={onSubmit}

--- a/src/renderer/containers/AddMetadataPage/index.tsx
+++ b/src/renderer/containers/AddMetadataPage/index.tsx
@@ -1,3 +1,4 @@
+import { ArrowLeftOutlined } from "@ant-design/icons";
 import { Alert, Button, Spin } from "antd";
 import { ipcRenderer } from "electron";
 import React from 'react';
@@ -12,6 +13,7 @@ import {
   getUploadError,
 } from "../../state/feedback/selectors";
 import { getImagingSessions } from "../../state/metadata/selectors";
+import { selectPage } from "../../state/route/actions";
 import {
   getAreSelectedUploadsInFlight,
   getSelectedUploads,
@@ -25,8 +27,6 @@ import {
 import CustomDataTable from '../CustomDataTable';
 
 import AddMetadataPageFooter from './AddMetadataPageFooter';
-import { selectPage } from "../../state/route/actions";
-import { ArrowLeftOutlined } from "@ant-design/icons";
 
 const styles = require("./styles.pcss");
 

--- a/src/renderer/containers/AddMetadataPage/index.tsx
+++ b/src/renderer/containers/AddMetadataPage/index.tsx
@@ -1,4 +1,4 @@
-import { Alert, Spin } from "antd";
+import { Alert, Button, Spin } from "antd";
 import { ipcRenderer } from "electron";
 import React from 'react';
 import { useDispatch, useSelector } from "react-redux";
@@ -14,9 +14,10 @@ import {
 import { getImagingSessions } from "../../state/metadata/selectors";
 import {
   getAreSelectedUploadsInFlight,
+  getSelectedUploads,
 } from "../../state/selection/selectors";
 import { getAppliedTemplate } from "../../state/template/selectors";
-import { AsyncRequest } from "../../state/types";
+import { AsyncRequest, Page } from "../../state/types";
 import { applyTemplate, updateUpload } from "../../state/upload/actions";
 import {
   getUploadValidationErrors,
@@ -24,6 +25,8 @@ import {
 import CustomDataTable from '../CustomDataTable';
 
 import AddMetadataPageFooter from './AddMetadataPageFooter';
+import { selectPage } from "../../state/route/actions";
+import { ArrowLeftOutlined } from "@ant-design/icons";
 
 const styles = require("./styles.pcss");
 
@@ -37,6 +40,7 @@ export default function AddMetadataPage() {
     const requestsInProgress = useSelector(getRequestsInProgress);
     const uploadError = useSelector(getUploadError);
     const validationErrors = useSelector(getUploadValidationErrors);
+    const selectedUploads = useSelector(getSelectedUploads);
 
     const [hasAttemptedSubmit, setHasAttemptedSubmit] = React.useState(false);
 
@@ -73,6 +77,17 @@ export default function AddMetadataPage() {
 
     return (
         <>
+            <div>
+            {!selectedUploads.length && // If we're adding new files, not editing ones that have been uploaded.
+              <Button
+                className={styles.returnButton}
+                onClick={() => dispatch(selectPage(Page.UploadWithTemplate))}
+                type="ghost"
+              >
+                <ArrowLeftOutlined /> Add More Files to Template
+              </Button>
+            }
+            </div>
             <div className={styles.contentContainer}>
             {!isSelectedJobLoading && (
             <>

--- a/src/renderer/containers/AddMetadataPage/index.tsx
+++ b/src/renderer/containers/AddMetadataPage/index.tsx
@@ -76,7 +76,7 @@ export default function AddMetadataPage() {
     }, [dispatch, imagingSessions]);
 
     return (
-        <>
+        <div>
             <div>
             {!selectedUploads.length && // If we're adding new files, not editing ones that have been uploaded.
               <Button
@@ -84,69 +84,69 @@ export default function AddMetadataPage() {
                 onClick={() => dispatch(selectPage(Page.UploadWithTemplate))}
                 type="ghost"
               >
-                <ArrowLeftOutlined /> Add More Files to Template
+                <span className={styles.returnButtonIcon}><ArrowLeftOutlined /></span> Add More Files to Template
               </Button>
             }
             </div>
-            <div className={styles.contentContainer}>
-            {!isSelectedJobLoading && (
-            <>
-                {hasAttemptedSubmit && !appliedTemplate && (
-                <Alert
-                    className={styles.alert}
-                    message="Please select a template."
-                    type="error"
-                    showIcon={true}
-                    key="template-not-selected"
-                />
-                )}
-                <LabeledInput
-                className={styles.selector}
-                label={`Select Metadata ${SCHEMA_SYNONYM}`}
-                >
-                <TemplateSearch
-                    allowCreate={true}
-                    disabled={isTemplateLoading || isReadOnly}
-                    error={hasAttemptedSubmit && !appliedTemplate}
-                    value={appliedTemplate?.templateId}
-                    onSelect={(t) => dispatch(applyTemplate(t))}
-                />
-                </LabeledInput>
-            </>
-            )}
-            {isSelectedJobLoading ? (
-            <div className={styles.spinContainer}>
-                <div>Loading...</div>
-                <Spin />
+            <div className={styles.tableContainer}>
+              {!isSelectedJobLoading && (
+              <>
+                  {hasAttemptedSubmit && !appliedTemplate && (
+                  <Alert
+                      className={styles.alert}
+                      message="Please select a template."
+                      type="error"
+                      showIcon={true}
+                      key="template-not-selected"
+                  />
+                  )}
+                  <LabeledInput
+                  className={styles.selector}
+                  label={`Select Metadata ${SCHEMA_SYNONYM}`}
+                  >
+                  <TemplateSearch
+                      allowCreate={true}
+                      disabled={isTemplateLoading || isReadOnly}
+                      error={hasAttemptedSubmit && !appliedTemplate}
+                      value={appliedTemplate?.templateId}
+                      onSelect={(t) => dispatch(applyTemplate(t))}
+                  />
+                  </LabeledInput>
+              </>
+              )}
+              {isSelectedJobLoading ? (
+              <div className={styles.spinContainer}>
+                  <div>Loading...</div>
+                  <Spin />
+              </div>
+              ) : (
+              <>
+                  {hasAttemptedSubmit && !!validationErrors.length && (
+                  <Alert
+                      className={styles.alert}
+                      message={validationErrors.map((e) => (
+                      <div key={e}>{e}</div>
+                      ))}
+                      showIcon={true}
+                      type="error"
+                      key="validation-errors"
+                  />
+                  )}
+                  <CustomDataTable hasSubmitBeenAttempted={hasAttemptedSubmit} />
+                  {uploadError && (
+                  <Alert
+                      className={styles.alert}
+                      message="Upload Failed"
+                      description={uploadError}
+                      type="error"
+                      showIcon={true}
+                      key="upload-failed"
+                  />
+                  )}
+              </>
+              )}
+              <AddMetadataPageFooter onSubmit={() => setHasAttemptedSubmit(true)} />
             </div>
-            ) : (
-            <>
-                {hasAttemptedSubmit && !!validationErrors.length && (
-                <Alert
-                    className={styles.alert}
-                    message={validationErrors.map((e) => (
-                    <div key={e}>{e}</div>
-                    ))}
-                    showIcon={true}
-                    type="error"
-                    key="validation-errors"
-                />
-                )}
-                <CustomDataTable hasSubmitBeenAttempted={hasAttemptedSubmit} />
-                {uploadError && (
-                <Alert
-                    className={styles.alert}
-                    message="Upload Failed"
-                    description={uploadError}
-                    type="error"
-                    showIcon={true}
-                    key="upload-failed"
-                />
-                )}
-            </>
-            )}
-        <AddMetadataPageFooter onSubmit={() => setHasAttemptedSubmit(true)} />
         </div>
-        </>
     )
 }

--- a/src/renderer/containers/AddMetadataPage/styles.pcss
+++ b/src/renderer/containers/AddMetadataPage/styles.pcss
@@ -32,3 +32,17 @@
   justify-content: center;
   flex-direction: column;
 }
+
+.return-button {
+  border: 1px solid white; /* should blend in with background */
+  box-shadow: none;
+  color: var(--brand-primary);
+
+  /* copied from antd button */
+  transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+.return-button:hover {
+  border: 1px solid #3db389;
+  color: #3db389;
+}

--- a/src/renderer/containers/AddMetadataPage/styles.pcss
+++ b/src/renderer/containers/AddMetadataPage/styles.pcss
@@ -4,7 +4,7 @@
   overflow-y: auto;
 }
 
-.content-container {
+.table-container {
   /* Flex-parent of data table */
   display: flex;
   flex-direction: column;
@@ -38,6 +38,14 @@
   box-shadow: none;
   color: var(--brand-primary);
 
+  display: flex;
+  align-items: center;
+
+  margin-left: 20px;
+  margin-top: 20px;
+  padding-bottom: 5px;
+  padding-top: 5px;
+
   /* copied from antd button */
   transition: all 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
@@ -45,4 +53,10 @@
 .return-button:hover {
   border: 1px solid #3db389;
   color: #3db389;
+}
+
+.return-button-icon {
+  font-size: 1.2em;
+  margin-right: 8px;
+  padding-top: 4px;
 }


### PR DESCRIPTION
closes #155 

Since the upload process is now split across two pages, we had to add a "back" button on the second page. In our first design, it was sandwiched right between "cancel upload" and "submit", which was pretty ugly. This PR moves it up to the top left of the page and adds an arrow to suggest it'll return you to the previous page.

Before:
<img width="1197" alt="add_more_before" src="https://github.com/user-attachments/assets/d3bff44a-1df7-4b81-ac53-6bd0783f5322" />

After:
<img width="1158" alt="add_more_after" src="https://github.com/user-attachments/assets/b4a68769-8eb9-4557-b087-3fe25b452f41" />

(I am aware the table looks weird)