### PR TITLE
(Small)[FUA-154] Update "selected files list" styling

### DIFF
--- a/src/renderer/containers/UploadSelectionPage/SelectedFilesList/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/SelectedFilesList/index.tsx
@@ -23,7 +23,7 @@ export default function SelectedFilesList(props: SelectedFilesListProps) {
 
     return (
         <div className={styles.container}>
-            <div className={styles.tableHeader}><strong>{props.uploadList.length}</strong> items will be uploaded</div>
+            <div className={styles.tableHeader}><strong>{props.uploadList.length}</strong> item(s) will be uploaded</div>
             <div className={styles.tableContainer}>
                 <table className={styles.table}>
                     <tbody>

--- a/src/renderer/containers/UploadSelectionPage/SelectedFilesList/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/SelectedFilesList/index.tsx
@@ -21,18 +21,14 @@ export default function SelectedFilesList(props: SelectedFilesListProps) {
 
     return (
         <div className={styles.container}>
-            <div>{props.uploadList.length} selected file(s)</div>
-            <table className={styles.table}>
-                <thead>
-                    <tr>
-                        <th className={styles.tableCell}>File Name</th>
-                        <th className={styles.tableCell}>Upload Type</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {rows}
-                </tbody>
-            </table>
+            <div className={styles.tableHeader}><strong>{props.uploadList.length}</strong> items will be uploaded</div>
+            <div className={styles.tableContainer}>
+                <table className={styles.table}>
+                    <tbody>
+                        {rows}
+                    </tbody>
+                </table>
+            </div>
         </div>
     )
 }

--- a/src/renderer/containers/UploadSelectionPage/SelectedFilesList/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/SelectedFilesList/index.tsx
@@ -1,3 +1,5 @@
+import { basename } from 'path';
+
 import React from 'react';
 
 import { FileModel } from '../../../state/types';
@@ -13,7 +15,7 @@ interface SelectedFilesListProps {
 export default function SelectedFilesList(props: SelectedFilesListProps) {
     const rows = props.uploadList.map(file => (
             <tr key={file.file}>
-                <td className={styles.tableCell}>{file.file}</td>
+                <td className={styles.tableCell}>{basename(file.file)}</td>
                 <td className={styles.tableCell}>{file.uploadType}</td>
             </tr>
         )

--- a/src/renderer/containers/UploadSelectionPage/SelectedFilesList/styles.pcss
+++ b/src/renderer/containers/UploadSelectionPage/SelectedFilesList/styles.pcss
@@ -33,6 +33,7 @@
     background-color: #F5F5F5;
     border-bottom: #CBCBCB;
     border-radius: 10px 10px 0px 0px;
+    color: #575859;
     font-size: 0.9em;
     padding-bottom: 12px;
     padding-left: 32px;

--- a/src/renderer/containers/UploadSelectionPage/SelectedFilesList/styles.pcss
+++ b/src/renderer/containers/UploadSelectionPage/SelectedFilesList/styles.pcss
@@ -31,7 +31,7 @@
 
 .table-header {
     background-color: #F5F5F5;
-    border-bottom: #CBCBCB;
+    border-bottom: 1px solid #CBCBCB;
     border-radius: 10px 10px 0px 0px;
     color: #575859;
     font-size: 0.9em;

--- a/src/renderer/containers/UploadSelectionPage/SelectedFilesList/styles.pcss
+++ b/src/renderer/containers/UploadSelectionPage/SelectedFilesList/styles.pcss
@@ -1,22 +1,41 @@
 .container {
-    background-color: #F5F5F5;
-    border: 1px solid black;    
+    border: 1px solid #CBCBCB;    
     border-radius: 10px;
     margin-bottom: 30px;
     margin-top: 30px;
-    padding: 12px;
     width: 100%;
 }
 
 .table {
     background-color: white;
-    border: 1px solid black;
-    border-collapse: collapse;
+    padding: 12px;
     width: 100%;
 }
 
+/* removes border from bottom table row */
+.table tr:last-child td {
+    border-bottom: none;
+}
+
 .table-cell {
-    border: 1px solid var(--grey);
-    padding: 8px;
+    border-bottom: 1px solid var(--grey);
+    padding-bottom: 15px;
+    padding-top: 15px;
     text-align: left;
+}
+
+.table-container {
+    padding-left: 32px;
+    padding-right: 32px;
+}
+
+.table-header {
+    background-color: #F5F5F5;
+    border-bottom: #CBCBCB;
+    border-radius: 10px 10px 0px 0px;
+    font-size: 0.9em;
+    padding-bottom: 12px;
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 12px;
 }

--- a/src/renderer/containers/UploadSelectionPage/SelectedFilesList/styles.pcss
+++ b/src/renderer/containers/UploadSelectionPage/SelectedFilesList/styles.pcss
@@ -19,8 +19,8 @@
 
 .table-cell {
     border-bottom: 1px solid var(--grey);
-    padding-bottom: 15px;
-    padding-top: 15px;
+    padding-bottom: 10px;
+    padding-top: 10px;
     text-align: left;
 }
 


### PR DESCRIPTION
closes #154 

### Description
Some minor styling changes to make the new "Selected Files List" (the list of files that pops up as you select stuff to upload)  a bit prettier / cleaner.

### Changes
* The table now only displays file names rather than full paths
* Removed table headers (should be self evident?)
* Removed more "lines" to make the design a bit cleaner

Before:
<img width="991" alt="file-list-before" src="https://github.com/user-attachments/assets/16c71bb6-a6e6-4d24-8b89-ca6880c56f53" />

After:
<img width="992" alt="file-list-after" src="https://github.com/user-attachments/assets/4ec434bb-fac5-4713-b342-409ed61da46b" />
