### PR TITLE
(Small) Styling pass

### DIFF
--- a/src/renderer/containers/AddMetadataPage/AddMetadataPageFooter/index.tsx
+++ b/src/renderer/containers/AddMetadataPage/AddMetadataPageFooter/index.tsx
@@ -60,6 +60,7 @@ export default function AddMetadataPageFooter(props: Props) {
     <PageFooter>
       <Button
               className={styles.cancelButton}
+              danger
               onClick={onCancel}
           >
               Cancel Upload

--- a/src/renderer/containers/AddMetadataPage/index.tsx
+++ b/src/renderer/containers/AddMetadataPage/index.tsx
@@ -75,7 +75,7 @@ export default function AddMetadataPage() {
     }, [dispatch, imagingSessions]);
 
     return (
-        <div>
+        <div className={styles.page}>
             <div>
             {!selectedUploads.length && // If we're adding new files, not editing ones that have been uploaded.
               <Button
@@ -99,14 +99,16 @@ export default function AddMetadataPage() {
                       key="template-not-selected"
                   />
                   )}
-                  <h1>Metadata {SCHEMA_SYNONYM}</h1>
-                  <TemplateSearch
-                      allowCreate={true}
-                      disabled={isTemplateLoading || isReadOnly}
-                      error={hasAttemptedSubmit && !appliedTemplate}
-                      value={appliedTemplate?.templateId}
-                      onSelect={(t) => dispatch(applyTemplate(t))}
-                  />
+                  <div className={styles.dropdown}>
+                    <h1>Metadata {SCHEMA_SYNONYM}</h1>
+                    <TemplateSearch
+                        allowCreate={true}
+                        disabled={isTemplateLoading || isReadOnly}
+                        error={hasAttemptedSubmit && !appliedTemplate}
+                        value={appliedTemplate?.templateId}
+                        onSelect={(t) => dispatch(applyTemplate(t))}
+                    />
+                  </div>
               </>
               )}
               {isSelectedJobLoading ? (
@@ -140,8 +142,8 @@ export default function AddMetadataPage() {
                   )}
               </>
               )}
-              <AddMetadataPageFooter onSubmit={() => setHasAttemptedSubmit(true)} />
             </div>
+            <AddMetadataPageFooter onSubmit={() => setHasAttemptedSubmit(true)} />
         </div>
     )
 }

--- a/src/renderer/containers/AddMetadataPage/index.tsx
+++ b/src/renderer/containers/AddMetadataPage/index.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { useDispatch, useSelector } from "react-redux";
 
 import { MainProcessEvents, SCHEMA_SYNONYM } from "../../../shared/constants";
-import LabeledInput from "../../components/LabeledInput";
 import TemplateSearch from "../../components/TemplateSearch";
 import { AnnotationName } from "../../constants";
 import {
@@ -100,10 +99,7 @@ export default function AddMetadataPage() {
                       key="template-not-selected"
                   />
                   )}
-                  <LabeledInput
-                  className={styles.selector}
-                  label={`Select Metadata ${SCHEMA_SYNONYM}`}
-                  >
+                  <h1>Metadata {SCHEMA_SYNONYM}</h1>
                   <TemplateSearch
                       allowCreate={true}
                       disabled={isTemplateLoading || isReadOnly}
@@ -111,7 +107,6 @@ export default function AddMetadataPage() {
                       value={appliedTemplate?.templateId}
                       onSelect={(t) => dispatch(applyTemplate(t))}
                   />
-                  </LabeledInput>
               </>
               )}
               {isSelectedJobLoading ? (

--- a/src/renderer/containers/AddMetadataPage/styles.pcss
+++ b/src/renderer/containers/AddMetadataPage/styles.pcss
@@ -4,6 +4,14 @@
   overflow-y: auto;
 }
 
+.dropdown {
+  margin-bottom: 1em;
+}
+
+.page {
+  margin-bottom: 75px;
+}
+
 .table-container {
   /* Flex-parent of data table */
   display: flex;

--- a/src/renderer/containers/Table/styles.pcss
+++ b/src/renderer/containers/Table/styles.pcss
@@ -12,6 +12,7 @@
 .table-container {
     background-color: var(--app-foreground-color);
     /* Variable located in styles/variables */
+    border-bottom: var(--border);
     border-left: var(--border);
     border-right: var(--border);
     display: flex;

--- a/src/renderer/containers/Table/styles.pcss
+++ b/src/renderer/containers/Table/styles.pcss
@@ -19,7 +19,6 @@
     flex-direction: column;
     flex-grow: 1;
     overflow-x: auto;
-    padding-bottom: 2px;
 }
 
 .table-cell, .table-header {

--- a/src/renderer/containers/UploadSelectionPage/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/index.tsx
@@ -76,6 +76,7 @@ export default function UploadSelectionPage() {
         <PageFooter>
           <Button
               className={styles.footerButton}
+              danger
               onClick={onCancel}
           >
               Cancel Upload

--- a/src/renderer/containers/UploadSelectionPage/styles.pcss
+++ b/src/renderer/containers/UploadSelectionPage/styles.pcss
@@ -1,5 +1,5 @@
 h1 {
-  font-size: 26px;
+  font-size: 22px;
   text-align: left;
   width: 100%;
 }


### PR DESCRIPTION
### Description
A (relatively) quick little group of styling adjustments before our next FUA release.

There are more things we could do to clean this up, but I'm at the point where I don't think they'd be worth the time.

### Changes
* Made the "Cancel Upload" buttons red
* "Select Metadata Template" -> "Metadata Template", and made the label an `<h1>`
* Fixed issue where the bottom border of the `<CustomDataTable>` wouldn't appear.
* Slightly reduced size of `<h1>`s

Before:
<img width="1322" alt="Screenshot 2025-02-17 at 1 28 56 PM" src="https://github.com/user-attachments/assets/99501bfd-d96f-402c-9139-522ae7b0efa6" />

After:
<img width="1297" alt="Screenshot 2025-02-17 at 1 28 11 PM" src="https://github.com/user-attachments/assets/33cb9ddd-11c8-43d7-823f-7aac104b3caa" />
