### PR TITLE
V3.4.1

### DIFF
--- a/VERSION_NOTES.md
+++ b/VERSION_NOTES.md
@@ -1,5 +1,8 @@
 # Version Notes
 
+## 3.4.0 (2/17/25)
+- Feature: Reworked upload flow to streamline UX and better support uploading "multifiles", AKA "chunked files".
+
 ## 3.3.4 (1/31/25)
 - Bugfix: App crashes when editing metadata of cloud-only upload
 

--- a/VERSION_NOTES.md
+++ b/VERSION_NOTES.md
@@ -1,5 +1,8 @@
 # Version Notes
 
+## 3.4.1 (2/18/25)
+- Feature: Minor styling updates to "AddMetadataPage".
+
 ## 3.4.0 (2/17/25)
 - Feature: Reworked upload flow to streamline UX and better support uploading "multifiles", AKA "chunked files".
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-upload-app",
-  "version": "3.3.4",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-upload-app",
-      "version": "3.3.4",
+      "version": "3.4.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-upload-app",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-upload-app",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "22.x",
     "npm": "10.x"
   },
-  "version": "3.4.0",
+  "version": "3.4.1",
   "build": {
     "appId": "org.aics.alleninstitute.fileupload",
     "artifactName": "file-upload-app-${version}.${ext}",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": "22.x",
     "npm": "10.x"
   },
-  "version": "3.3.4",
+  "version": "3.4.0",
   "build": {
     "appId": "org.aics.alleninstitute.fileupload",
     "artifactName": "file-upload-app-${version}.${ext}",


### PR DESCRIPTION
Updates the version notes and package number for the already-released `3.4.0` and `3.4.1` File Upload App versions.

Jumped a minor version because the upload flow was visually reworked to account for uploading multifiles (AKA chunked files). Jumped a patch version because I still had minor styling changes to merge this morning 🤔 .