### PR TITLE
Fix for react devtools failing to load- ignore if it does

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -61,8 +61,12 @@ function createMainWindow() {
                   console.error("Failed to load from webpack-dev-server", error);
               });
       })
-      .catch((err: Error) =>
-          console.error("An error occurred loading React Dev Tools: ", err)
+      .catch((err: Error) => {
+          console.log(`Failed to load React devtools \n ${err}`);
+          window.loadFile(path.join("dist", "renderer", "index.html")).catch((error: Error) => {
+            console.error("Failed to load from file", error);
+          });
+        }
       )
       .finally(() => window.webContents.openDevTools());
   } else {


### PR DESCRIPTION
Currently, when installing FUA with `npm install` react devtools will fail to load due to a bad version of `electron-devtools-instealler`. When react devtools fails to load, the whole electon app doesnt load as that will block app loading.

I've tried a couple different versions of `electron-devtools-installer` (`3.1.0`, `3.2.0`, and `4.0.0`) but couldnt resolve this issue. We should make it so that if react devtools fails to load- the rest of the app still loads correctly.

