### PR TITLE
Fix broken build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Initialize
         uses: actions/setup-node@v1
         with:
-          node-version: 22
+          node-version: 22.17
       - name: Install Dependencies
         run: npm install
       - name: Lint


### PR DESCRIPTION
node `22.18` introduces [type stripping enabled by default](https://github.com/nodejs/node/releases?utm_source=chatgpt.com) which is breaking our mocha tests.

Discussed with @tyler-foster and for an immediate build fix I am pinning node 22.17 for now. Created a ticket with details for a fix soon https://github.com/aics-int/aics-file-upload-app/issues/199.

