### PR TITLE
Exclude JSON files from ESLint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-upload-app",
-  "version": "3.4.5-snapshot.0",
+  "version": "3.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-upload-app",
-      "version": "3.4.5-snapshot.0",
+      "version": "3.4.4",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
Releasing was blocked since changes to json files during the release process (while running `npm version prerelease --preid=snapshot` to bump versions) caused ESLint failures during the pre-commit hook. [This was introduced in this pr.](https://github.com/aics-int/aics-file-upload-app/pull/217/files)

```
npm error
npm error ✖ eslint --cache --fix:
npm error
npm error /Users/brian.kim/work/aics-file-upload-app/package-lock.json
npm error   0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
npm error The file does not match your project config: package-lock.json.
npm error You unnecessarily included the extension ".ts" with the "extraFileExtensions" option. This extension is already handled by the parser by default.
npm error You unnecessarily included the extension ".tsx" with the "extraFileExtensions" option. This extension is already handled by the parser by default.
npm error The file must be included in at least one of the projects provided
npm error
npm error /Users/brian.kim/work/aics-file-upload-app/package.json
npm error   0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
npm error The file does not match your project config: package.json.
npm error You unnecessarily included the extension ".ts" with the "extraFileExtensions" option. This extension is already handled by the parser by default.
npm error You unnecessarily included the extension ".tsx" with the "extraFileExtensions" option. This extension is already handled by the parser by default.
npm error The file must be included in at least one of the projects provided
npm error
npm error ✖ 2 problems (2 errors, 0 warnings)
npm error
npm error husky - pre-commit hook exited with code 1 (error)
```

It looks like this project uses `@typescript-eslint/parser` which can only be used for `.js`, `.jsx`, `.ts`, `.tsx` files, so I've reverted the aforementioned pr's changes to the `ESLint` configuration (while keeping `prettier` on for these files so formatting still happens).

Note: [we can use `ESLint` for JSON linting](https://eslint.org/blog/2024/10/eslint-json-markdown-support/)- but we need to configure `@eslint/json` for that- lmk if this is something we want, and I will make a ticket for it.