### PR TITLE
Re-enable view metadata modal

### DIFF
--- a/src/renderer/containers/CustomDataTable/selectors.tsx
+++ b/src/renderer/containers/CustomDataTable/selectors.tsx
@@ -17,7 +17,7 @@ import ImagingSessionCell from "../Table/CustomCells/ImagingSessionCell";
 import NotesCell from "../Table/CustomCells/NotesCell";
 import PlateBarcodeCell from "../Table/CustomCells/PlateBarcodeCell";
 import ProgramCell from "../Table/CustomCells/ProgramCell";
-// import SeeMetadataCell from "../Table/CustomCells/SeeMetadataCell"; TODO: Re-enable when mxs ready
+import SeeMetadataCell from "../Table/CustomCells/SeeMetadataCell";
 import SelectionCell from "../Table/CustomCells/SelectionCell";
 import WellCell from "../Table/CustomCells/WellCell";
 import ReadOnlyCell from "../Table/DefaultCells/ReadOnlyCell";
@@ -146,14 +146,13 @@ export const getCanShowImagingSessionColumn = createSelector(
     )
 );
 
-// TODO: Re enable when MXS is ready
-// const METADATA_COLUMN: CustomColumn = {
-//   id: "SeeMetadata",
-//   Header: "",
-//   Cell: SeeMetadataCell,
-//   disableResizing: true,
-//   width: 135,
-// };
+const METADATA_COLUMN: CustomColumn = {
+  id: "SeeMetadata",
+  Header: "",
+  Cell: SeeMetadataCell,
+  disableResizing: true,
+  width: 135,
+};
 
 // Uses shallow equality comparable selectors to avoid
 // re-rendering on each upload state change which would
@@ -215,7 +214,7 @@ export const getColumnsForTable = createSelector(
       SELECTION_COLUMN,
       ...DEFAULT_COLUMNS,
       ...templateColumns,
-      // METADATA_COLUMN, # TODO: Re-enable when mxs ready
+      METADATA_COLUMN,
     ];
   }
 );

--- a/src/renderer/containers/CustomDataTable/test/selectors.test.ts
+++ b/src/renderer/containers/CustomDataTable/test/selectors.test.ts
@@ -276,10 +276,8 @@ describe("CustomDataTable selectors", () => {
       });
 
       // Assert
-      // expect(actual.length).to.equal(11);
-      // expect(actual.filter((c) => !c.isReadOnly)).to.be.lengthOf(11);
-      expect(actual.filter((c) => !c.isReadOnly)).to.be.lengthOf(10); // TODO: Change to above when MXS feature released
-      expect(actual.length).to.equal(10); // TODO: Change to above when MXS feature released
+      expect(actual.length).to.equal(11);
+      expect(actual.filter((c) => !c.isReadOnly)).to.be.lengthOf(11);
       expect(actual.some((c) => c.id === "selection")).to.be.true;
       expect(actual.some((c) => c.accessor === "file")).to.be.true;
       expect(actual.some((c) => c.accessor === AnnotationName.NOTES)).to.be


### PR DESCRIPTION
in https://github.com/aics-int/aics-file-upload-app/pulls?q=is%3Apr+is%3Aclosed I disabled the view metadata modal with some comments due to ongoing MXS work needed to support this functionality.

small pr to re-enable this, and fix a related test

