### PR TITLE
"View Metadata" window optimization

### DIFF
--- a/src/renderer/containers/Table/CustomCells/SeeMetadataCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/SeeMetadataCell/index.tsx
@@ -22,8 +22,10 @@ export default function SeeMetadataCell(props: CellProps<any>) {
 
   const showMetadata = () => {
     setIsModalVisible(true);
-    // dispatch action to fetch metadata
-    dispatch(fetchMetadataRequest(filePath));
+    // Only fetch metadata if not already cached
+    if (!metadataState.metadata) {
+      dispatch(fetchMetadataRequest(filePath));
+    }
   };
 
   const handleCancel = () => {


### PR DESCRIPTION
Currently, FUA makes a second mxs call when the view metadata window is opened, rather than using the already cached metadata available in state.

Small change so that if we have metadata available for the file already from mxs, we are not making a second mxs call for this.