### PR TITLE
Bugfix: Some items not being autofilled initially

### DIFF
--- a/src/renderer/containers/UploadSelectionPage/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/index.tsx
@@ -51,10 +51,12 @@ export default function UploadSelectionPage() {
     dispatch(closeUpload());
   };
 
-  const onContinue = () => {
+  const onContinue = async () => {
     const templateId = appliedTemplateId || savedTemplateId;
     if (templateId) {
-      dispatch(applyTemplate(templateId));
+      // Ensure template application completes before navigating to avoid
+      // late state updates clobbering user edits on the metadata page.
+      await (dispatch as any)(applyTemplate(templateId));
     }
     dispatch(selectPage(Page.AddMetadata));
   };


### PR DESCRIPTION
**Bug Description**
Some files were not being autofilled with known metadata in the metadata template. I saw that template auto-application was racing with metadata fetching, sometimes causing some files to not have metadata autofilled.

**Fix**
I apply the template on the "Continue to Metadata" button click- since the button is already disabled until all metadata is loaded, this makes sure that a complete autofill of all files is possible.

This should have been done in https://github.com/aics-int/aics-file-upload-app/pull/243 and is therefore an extension of that pr, see for related changes.