### PR TITLE
Bugfix: some template items not being autofilled

### DIFF
--- a/src/renderer/containers/UploadSelectionPage/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from "antd";
+import { Button, Spin, Tooltip } from "antd";
 import { OpenDialogOptions } from "electron";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -102,6 +102,7 @@ export default function UploadSelectionPage() {
               </Button>
             </span>
           </Tooltip>
+          {isMxsLoading && <Spin size="small" />}
         </PageFooter>
       </div>
     </div>

--- a/src/renderer/containers/UploadSelectionPage/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/index.tsx
@@ -51,10 +51,12 @@ export default function UploadSelectionPage() {
     dispatch(closeUpload());
   };
 
-  const onContinue = () => {
+  const onContinue = async () => {
     const templateId = appliedTemplateId || savedTemplateId;
     if (templateId) {
-      dispatch(applyTemplate(templateId));
+      // Ensure template application completes before navigating to avoid
+      // late state updates clobbering user edits on the metadata page.
+      await (dispatch as any)(applyTemplate(templateId));
     }
     dispatch(selectPage(Page.AddMetadata));
   };

--- a/src/renderer/containers/UploadSelectionPage/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/index.tsx
@@ -9,7 +9,10 @@ import { getIsAnyMetadataExtractionLoading } from "../../state/metadataExtractio
 import { closeUpload, selectPage } from "../../state/route/actions";
 import { loadFiles } from "../../state/selection/actions";
 import { getUploadType } from "../../state/selection/selectors";
+import { getTemplateId } from "../../state/setting/selectors";
+import { getAppliedTemplate } from "../../state/template/selectors";
 import { Page } from "../../state/types";
+import { applyTemplate } from "../../state/upload/actions";
 import { getUploadAsTableRows } from "../../state/upload/selectors";
 import { UploadType } from "../../types";
 
@@ -29,6 +32,8 @@ export default function UploadSelectionPage() {
   const isMxsLoading = useSelector(getIsAnyMetadataExtractionLoading);
   const uploadType = useSelector(getUploadType);
   const uploadList = useSelector(getUploadAsTableRows);
+  const appliedTemplateId = useSelector(getAppliedTemplate)?.templateId;
+  const savedTemplateId = useSelector(getTemplateId);
 
   // Default to "File" option
   let openDialogOptions: OpenDialogOptions = {
@@ -47,6 +52,10 @@ export default function UploadSelectionPage() {
   };
 
   const onContinue = () => {
+    const templateId = appliedTemplateId || savedTemplateId;
+    if (templateId) {
+      dispatch(applyTemplate(templateId));
+    }
     dispatch(selectPage(Page.AddMetadata));
   };
 

--- a/src/renderer/containers/UploadSelectionPage/index.tsx
+++ b/src/renderer/containers/UploadSelectionPage/index.tsx
@@ -54,8 +54,8 @@ export default function UploadSelectionPage() {
   const onContinue = async () => {
     const templateId = appliedTemplateId || savedTemplateId;
     if (templateId) {
-      // Ensure template application completes before navigating to avoid
-      // late state updates clobbering user edits on the metadata page.
+      // ensure template applies before switching page
+      // also autofills all known metadata
       await (dispatch as any)(applyTemplate(templateId));
     }
     dispatch(selectPage(Page.AddMetadata));

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -38,6 +38,7 @@ import {
   getSelectedUploads,
   getSelectedUser,
 } from "../selection/selectors";
+import { getTemplateId } from "../setting/selectors";
 import { ensureDraftGetsSaved, getApplyTemplateInfo } from "../stateHelpers";
 import { setAppliedTemplate } from "../template/actions";
 import { getAppliedTemplate } from "../template/selectors";
@@ -56,6 +57,7 @@ import { batchActions } from "../util";
 
 import {
   addUploadFiles,
+  applyTemplate,
   cancelUploadFailed,
   cancelUploadSucceeded,
   editFileMetadataFailed,

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -155,10 +155,17 @@ const applyTemplateLogic = createLogic({
 
 const addUploadFilesLogic = createLogic({
   process: (
-    _deps: ReduxLogicProcessDependencies,
-    _dispatch: ReduxLogicNextCb,
+    { getState }: ReduxLogicProcessDependencies,
+    dispatch: ReduxLogicNextCb,
     done: ReduxLogicDoneCb
   ) => {
+    const selectedTemplate = getAppliedTemplate(getState())?.templateId;
+    const savedTemplate = getTemplateId(getState());
+    if (selectedTemplate) {
+      dispatch(applyTemplate(selectedTemplate));
+    } else if (savedTemplate) {
+      dispatch(applyTemplate(savedTemplate));
+    }
     done();
   },
   type: ADD_UPLOAD_FILES,

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -38,7 +38,6 @@ import {
   getSelectedUploads,
   getSelectedUser,
 } from "../selection/selectors";
-import { getTemplateId } from "../setting/selectors";
 import { ensureDraftGetsSaved, getApplyTemplateInfo } from "../stateHelpers";
 import { setAppliedTemplate } from "../template/actions";
 import { getAppliedTemplate } from "../template/selectors";
@@ -57,7 +56,6 @@ import { batchActions } from "../util";
 
 import {
   addUploadFiles,
-  applyTemplate,
   cancelUploadFailed,
   cancelUploadSucceeded,
   editFileMetadataFailed,
@@ -157,17 +155,10 @@ const applyTemplateLogic = createLogic({
 
 const addUploadFilesLogic = createLogic({
   process: (
-    { getState }: ReduxLogicProcessDependencies,
-    dispatch: ReduxLogicNextCb,
+    _deps: ReduxLogicProcessDependencies,
+    _dispatch: ReduxLogicNextCb,
     done: ReduxLogicDoneCb
   ) => {
-    const selectedTemplate = getAppliedTemplate(getState())?.templateId;
-    const savedTemplate = getTemplateId(getState());
-    if (selectedTemplate) {
-      dispatch(applyTemplate(selectedTemplate));
-    } else if (savedTemplate) {
-      dispatch(applyTemplate(savedTemplate));
-    }
     done();
   },
   type: ADD_UPLOAD_FILES,

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -38,7 +38,6 @@ import {
   getSelectedUploads,
   getSelectedUser,
 } from "../selection/selectors";
-import { getTemplateId } from "../setting/selectors";
 import { ensureDraftGetsSaved, getApplyTemplateInfo } from "../stateHelpers";
 import { setAppliedTemplate } from "../template/actions";
 import { getAppliedTemplate } from "../template/selectors";
@@ -48,7 +47,6 @@ import {
   PlateAtImagingSession,
   ReduxLogicDoneCb,
   ReduxLogicNextCb,
-  ReduxLogicProcessDependencies,
   ReduxLogicProcessDependenciesWithAction,
   ReduxLogicRejectCb,
   ReduxLogicTransformDependenciesWithAction,
@@ -57,7 +55,6 @@ import { batchActions } from "../util";
 
 import {
   addUploadFiles,
-  applyTemplate,
   cancelUploadFailed,
   cancelUploadSucceeded,
   editFileMetadataFailed,
@@ -69,7 +66,6 @@ import {
   uploadFailed,
 } from "./actions";
 import {
-  ADD_UPLOAD_FILES,
   APPLY_TEMPLATE,
   CANCEL_UPLOADS,
   INITIATE_UPLOAD,
@@ -153,24 +149,6 @@ const applyTemplateLogic = createLogic({
     done();
   },
   type: APPLY_TEMPLATE,
-});
-
-const addUploadFilesLogic = createLogic({
-  process: (
-    { getState }: ReduxLogicProcessDependencies,
-    dispatch: ReduxLogicNextCb,
-    done: ReduxLogicDoneCb
-  ) => {
-    const selectedTemplate = getAppliedTemplate(getState())?.templateId;
-    const savedTemplate = getTemplateId(getState());
-    if (selectedTemplate) {
-      dispatch(applyTemplate(selectedTemplate));
-    } else if (savedTemplate) {
-      dispatch(applyTemplate(savedTemplate));
-    }
-    done();
-  },
-  type: ADD_UPLOAD_FILES,
 });
 
 const initiateUploadLogic = createLogic({
@@ -802,7 +780,6 @@ const uploadWithoutMetadataLogic = createLogic({
 });
 
 export default [
-  addUploadFilesLogic,
   applyTemplateLogic,
   cancelUploadsLogic,
   initiateUploadLogic,

--- a/src/renderer/state/upload/test/logics.test.ts
+++ b/src/renderer/state/upload/test/logics.test.ts
@@ -888,55 +888,6 @@ describe("Upload logics", () => {
     });
   });
 
-  describe("addUploadFilesLogic", () => {
-    it("applies selected templated over saved template", async () => {
-      // arrange
-      const templateId = 17;
-      const badTemplateId = 4;
-      const { actions, logicMiddleware, store } = createMockReduxStore({
-        ...mockState,
-        template: {
-          ...mockTemplateStateBranch,
-          appliedTemplate: {
-            ...mockTemplateWithManyValues,
-            templateId,
-          },
-        },
-        setting: {
-          ...mockState.setting,
-          templateId: badTemplateId,
-        },
-      });
-
-      // act
-      store.dispatch(addUploadFiles([]));
-      await logicMiddleware.whenComplete();
-
-      // assert
-      expect(actions.includesMatch(applyTemplate(badTemplateId))).to.be.false;
-      expect(actions.includesMatch(applyTemplate(templateId))).to.be.true;
-    });
-
-    it("applies saved template", async () => {
-      // arrange
-      const templateId = 17;
-      const { actions, logicMiddleware, store } = createMockReduxStore({
-        ...mockState,
-        setting: {
-          ...mockState.setting,
-          templateId,
-        },
-      });
-
-      // act
-      store.dispatch(addUploadFiles([]));
-      await logicMiddleware.whenComplete();
-
-      // assert
-      expect(actions.includesMatch(applyTemplate(templateId))).to.be.true;
-    });
-  });
-
   describe("updateUploadRowsLogic", () => {
     it("updates a single upload", () => {
       // arrange


### PR DESCRIPTION
**Bug Description**
Some files were not being autofilled with known metadata in the metadata template. I saw that template auto-application was racing with metadata fetching, sometimes causing some files to not have metadata autofilled.

**Fix**
I apply the template on the "Continue to Metadata" button click- since the button is already disabled until all metadata is loaded, this makes sure that a complete autofill of all files is possible.

This should have been done in https://github.com/aics-int/aics-file-upload-app/pull/243 and is therefore an extension of that pr, see for related changes.

https://github.com/user-attachments/assets/c882bf2c-bd9d-4fc6-b7ab-f8814ca419fd


