### PR TITLE
Feedback for incorrect annotation type

### DIFF
--- a/src/renderer/containers/Table/DefaultCells/DefaultCell.tsx
+++ b/src/renderer/containers/Table/DefaultCells/DefaultCell.tsx
@@ -30,15 +30,18 @@ export default function DefaultCell(props: CellProps<FileModel, ColumnValue>) {
 
   function commitChanges(value: ColumnValue) {
     setIsEditing(false);
+    dispatch(updateUpload(props.row.id, { [props.column.id]: value }));
+  }
 
-    if (column.type === ColumnType.NUMBER && Number.isNaN(Number(value))) {
+  function commitNumberChanges(value: ColumnValue) {
+    if (Number.isNaN(Number(value))) {
+      setIsEditing(false);
       setHasTypeError(true);
       setTimeout(() => setHasTypeError(false), 1000);
       dispatch(setErrorAlert(`${column.id} expects a number value`));
       return;
     }
-
-    dispatch(updateUpload(props.row.id, { [props.column.id]: value }));
+    commitChanges(value);
   }
 
   if (isEditing) {
@@ -51,11 +54,17 @@ export default function DefaultCell(props: CellProps<FileModel, ColumnValue>) {
           />
         );
       case ColumnType.TEXT:
-      case ColumnType.NUMBER:
         return (
           <TextEditor
             initialValue={value as string[]}
             commitChanges={commitChanges}
+          />
+        );
+      case ColumnType.NUMBER:
+        return (
+          <TextEditor
+            initialValue={value as string[]}
+            commitChanges={commitNumberChanges}
           />
         );
       case ColumnType.DURATION:

--- a/src/renderer/containers/Table/DefaultCells/DefaultCell.tsx
+++ b/src/renderer/containers/Table/DefaultCells/DefaultCell.tsx
@@ -26,10 +26,14 @@ export default function DefaultCell(props: CellProps<FileModel, ColumnValue>) {
   const { column, value } = props;
   const dispatch = useDispatch();
   const [isEditing, setIsEditing] = useState(false);
+  const [hasTypeError, setHasTypeError] = useState(false);
+
   function commitChanges(value: ColumnValue) {
     setIsEditing(false);
 
     if (column.type === ColumnType.NUMBER && Number.isNaN(Number(value))) {
+      setHasTypeError(true);
+      setTimeout(() => setHasTypeError(false), 1000);
       dispatch(setErrorAlert(`${column.id} expects a number value`));
       return;
     }
@@ -94,5 +98,11 @@ export default function DefaultCell(props: CellProps<FileModel, ColumnValue>) {
     }
   }
 
-  return <DisplayCell {...props} onStartEditing={() => setIsEditing(true)} />;
+  return (
+    <DisplayCell
+      {...props}
+      hasTypeError={hasTypeError}
+      onStartEditing={() => setIsEditing(true)}
+    />
+  );
 }

--- a/src/renderer/containers/Table/DefaultCells/DefaultCell.tsx
+++ b/src/renderer/containers/Table/DefaultCells/DefaultCell.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 import { CellProps } from "react-table";
 
 import { ColumnType } from "../../../services/labkey-client/types";
+import { setErrorAlert } from "../../../state/feedback/actions";
 import { FileModel } from "../../../state/types";
 import { updateUpload } from "../../../state/upload/actions";
 import { Duration } from "../../../types";
@@ -25,9 +26,14 @@ export default function DefaultCell(props: CellProps<FileModel, ColumnValue>) {
   const { column, value } = props;
   const dispatch = useDispatch();
   const [isEditing, setIsEditing] = useState(false);
-
   function commitChanges(value: ColumnValue) {
     setIsEditing(false);
+
+    if (column.type === ColumnType.NUMBER && Number.isNaN(Number(value))) {
+      dispatch(setErrorAlert(`${column.id} expects a number value`));
+      return;
+    }
+
     dispatch(updateUpload(props.row.id, { [props.column.id]: value }));
   }
 

--- a/src/renderer/containers/Table/DefaultCells/DisplayCell/index.tsx
+++ b/src/renderer/containers/Table/DefaultCells/DisplayCell/index.tsx
@@ -31,6 +31,7 @@ const styles = require("./styles.pcss");
 
 interface Props extends CellProps<FileModel> {
   disabled?: boolean;
+  hasTypeError?: boolean;
   onStartEditing: () => void;
   onTabExit?: () => void;
 }
@@ -231,6 +232,7 @@ export default function DisplayCell(props: Props) {
             className={classNames(styles.readOnlyCell, {
               [styles.highlight]: isHighlighted,
               [styles.autofilled]: isAutofilled,
+              [styles.typeErrorFlash]: props.hasTypeError,
             })}
             onKeyDown={onDisplayInputKeyDown}
             onBlur={() => setIsActive(false)}

--- a/src/renderer/containers/Table/DefaultCells/DisplayCell/styles.pcss
+++ b/src/renderer/containers/Table/DefaultCells/DisplayCell/styles.pcss
@@ -67,3 +67,12 @@
     border: none;
     border-color: transparent;
 }
+
+@keyframes flash-error {
+    0% { background-color: var(--error); }
+    100% { background-color: transparent; }
+}
+
+.type-error-flash {
+    animation: flash-error 1s ease-out;
+}


### PR DESCRIPTION
**Description**
This is re this ticket:
https://github.com/orgs/aics-int/projects/30/views/1?pane=issue&itemId=71299670&issue=aics-int%7Caics-file-upload-app%7C100

When a user enters a string in a number cell, currently the app just deletes the value without any feedback.

**Solution**

- Added error message when non numerical value is entered into a numberical cell
- Cell also flashes red for extra feedback

https://github.com/user-attachments/assets/2981a504-a6ca-45c7-a55b-d948cadbbb4f

**Changes**

- Changed `DefaultCell`'s `commitChanges()` function called after each change to the cell to validation numerical values.
If the value entered cannot be type cast to a Number, dispatches an error alert, and set's cell's state to `hasTypeError = True`, for 1000ms, triggering a short red flashing effect on the cell.


**Other Considerations**
Text entered in a numerical cell should be the only type we need to check as per the original ticket's main complaint (we are using a `TextEditor`) which can be an invalid `Number`, and other types do not have this issue:

- Text: uses `TextEditor` so any string / number can be accepted
- Boolean: uses `BooleanEditor` and can only be toggled yes/no
- Dropdown: uses `DropdownEdtior` and cannot enter anything beyond the options list provided
- Lookup: uses LookupEditor and cant enter wrong type here
- Date/DateTime: uses `DateEditor` so cant enter wrong type as well
