### PR TITLE
Change cell error flash color

### DIFF
--- a/src/renderer/containers/Table/DefaultCells/DisplayCell/styles.pcss
+++ b/src/renderer/containers/Table/DefaultCells/DisplayCell/styles.pcss
@@ -69,7 +69,7 @@
 }
 
 @keyframes flash-error {
-    0% { background-color: var(--error); }
+    0% { background-color: #FEE0DE; }
     100% { background-color: transparent; }
 }
 


### PR DESCRIPTION
Travis requested that the flashing red color be changed for the cell error.

previously we were using the default error color, now changed to #FEE0DE.

(It looks like we use the default red color in a couple other css files, but maybe we should change all error colors to #FEE0DE? For now just doing it in this one place.)

The new color looks like this:


https://github.com/user-attachments/assets/2591d285-b125-4ea2-bbad-f7637f8e6417



