### PR TITLE
Upload extracted metadata from clients

### DIFF
--- a/src/renderer/state/metadataExtraction/logics.ts
+++ b/src/renderer/state/metadataExtraction/logics.ts
@@ -1,5 +1,8 @@
 import { createLogic } from "redux-logic";
 
+import { DAY_AS_MS, HOUR_AS_MS, MINUTE_AS_MS } from "../../constants";
+import { Duration } from "../../types";
+import { getDurationAnnotationTypeId } from "../metadata/selectors";
 import {
   fetchMetadataSucceeded,
   fetchMetadataFailed,
@@ -18,6 +21,18 @@ import {
 import { autofillFromMXS } from "../upload/actions";
 import { ADD_UPLOAD_FILES } from "../upload/constants";
 import { AddUploadFilesAction } from "../upload/types";
+
+function msToDuration(ms: number): Duration {
+  let remaining = ms;
+  const days = Math.floor(remaining / DAY_AS_MS);
+  remaining -= days * DAY_AS_MS;
+  const hours = Math.floor(remaining / HOUR_AS_MS);
+  remaining -= hours * HOUR_AS_MS;
+  const minutes = Math.floor(remaining / MINUTE_AS_MS);
+  remaining -= minutes * MINUTE_AS_MS;
+  const seconds = Math.floor(remaining / 1000);
+  return { days, hours, minutes, seconds };
+}
 
 // fetches MXS data and stores in metadataExtraction state
 const fetchMetadataLogic = createLogic({
@@ -72,15 +87,34 @@ const autofillOnTemplateAppliedLogic = createLogic({
   ) => {
     const state = getState();
     const uploads = action.payload?.uploads;
+    const template = action.payload?.template;
     if (!uploads) {
       done();
       return;
     }
 
+    const durationTypeId = getDurationAnnotationTypeId(state);
+    const durationAnnotationNames = new Set(
+      (template?.annotations || [])
+        .filter((a) => a.annotationTypeId === durationTypeId)
+        .map((a) => a.name)
+    );
+
     for (const filePath of Object.keys(uploads)) {
       const cachedMetadata = state.metadataExtraction[filePath]?.metadata;
       if (cachedMetadata) {
-        dispatch(autofillFromMXS(filePath, cachedMetadata));
+        const convertedMetadata = Object.fromEntries(
+          Object.entries(cachedMetadata).map(([name, entry]) => {
+            if (
+              durationAnnotationNames.has(name) &&
+              typeof entry.value === "number"
+            ) {
+              return [name, { ...entry, value: msToDuration(entry.value) }];
+            }
+            return [name, entry];
+          })
+        );
+        dispatch(autofillFromMXS(filePath, convertedMetadata as any));
       }
     }
     done();

--- a/src/renderer/state/metadataExtraction/logics.ts
+++ b/src/renderer/state/metadataExtraction/logics.ts
@@ -103,18 +103,20 @@ const autofillOnTemplateAppliedLogic = createLogic({
     for (const filePath of Object.keys(uploads)) {
       const cachedMetadata = state.metadataExtraction[filePath]?.metadata;
       if (cachedMetadata) {
-        const convertedMetadata = Object.fromEntries(
-          Object.entries(cachedMetadata).map(([name, entry]) => {
-            if (
-              durationAnnotationNames.has(name) &&
-              typeof entry.value === "number"
-            ) {
-              return [name, { ...entry, value: msToDuration(entry.value) }];
-            }
-            return [name, entry];
-          })
-        );
-        dispatch(autofillFromMXS(filePath, convertedMetadata as any));
+        // sometimes metadata from mxs needs to be converted into a format
+        // we can render in the ui, do these conversions here
+        const convertedMetadata: Record<string, any> = { ...cachedMetadata };
+        // convert durations
+        for (const name of durationAnnotationNames) {
+          const entry = convertedMetadata[name];
+          if (entry) {
+            convertedMetadata[name] = {
+              ...entry,
+              value: msToDuration(entry.value as number),
+            };
+          }
+        }
+        dispatch(autofillFromMXS(filePath, convertedMetadata));
       }
     }
     done();

--- a/src/renderer/state/metadataExtraction/logics.ts
+++ b/src/renderer/state/metadataExtraction/logics.ts
@@ -22,7 +22,7 @@ import { autofillFromMXS } from "../upload/actions";
 import { ADD_UPLOAD_FILES } from "../upload/constants";
 import { AddUploadFilesAction } from "../upload/types";
 
-function msToDuration(ms: number): Duration {
+export function msToDuration(ms: number): Duration {
   let remaining = ms;
   const days = Math.floor(remaining / DAY_AS_MS);
   remaining -= days * DAY_AS_MS;

--- a/src/renderer/state/metadataExtraction/test/logics.test.ts
+++ b/src/renderer/state/metadataExtraction/test/logics.test.ts
@@ -19,7 +19,7 @@ import {
   FETCH_METADATA_SUCCEEDED,
   FETCH_METADATA_FAILED,
 } from "../constants";
-import logics from "../logics";
+import logics, { msToDuration } from "../logics";
 
 describe("metadataExtraction logics", () => {
   const sandbox = createSandbox();
@@ -355,6 +355,31 @@ describe("metadataExtraction logics", () => {
 
       expect(autofillActions).to.have.length(1);
       expect(autofillActions[0].payload.filePath).to.equal(fileWithMetadata);
+    });
+  });
+
+  describe("msToDuration", () => {
+    it("converts milliseconds to a Duration object", () => {
+      const ms =
+        2 * 24 * 60 * 60 * 1000 + // 2 days
+        3 * 60 * 60 * 1000 + // 3 hours
+        4 * 60 * 1000 + // 4 minutes
+        5 * 1000; // 5 seconds
+      expect(msToDuration(ms)).to.deep.equal({
+        days: 2,
+        hours: 3,
+        minutes: 4,
+        seconds: 5,
+      });
+    });
+
+    it("returns zeros for 0ms", () => {
+      expect(msToDuration(0)).to.deep.equal({
+        days: 0,
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      });
     });
   });
 });

--- a/src/renderer/state/upload/reducer.ts
+++ b/src/renderer/state/upload/reducer.ts
@@ -195,7 +195,7 @@ const actionToConfigMap: TypeToDescriptionMap<UploadStateBranch> = {
 
       Object.entries(mxsResult).forEach(([annotationName, { value }]) => {
         if (value !== null && value !== undefined && value !== "") {
-          // always use MXS value since MXS will override on backend anyway
+          // always use MXS value; also send to MMS on upload and MXS may update later
           autofillData[annotationName] = Array.isArray(value) ? value : [value];
           autofilledFields.push(annotationName);
         }

--- a/src/renderer/state/upload/selectors.ts
+++ b/src/renderer/state/upload/selectors.ts
@@ -473,7 +473,6 @@ export const getExtractedAnnotationsNotInTemplate = (
       if (
         !templateAnnotationNames.has(annotationName) &&
         value !== null &&
-        value !== undefined &&
         value !== ""
       ) {
         accum.push({

--- a/src/renderer/state/upload/selectors.ts
+++ b/src/renderer/state/upload/selectors.ts
@@ -471,7 +471,7 @@ export const getExtractedAnnotations = (
     .filter(({ value }) => value !== null && value !== "")
     .map(({ annotation_id, value }) => ({
       annotationId: annotation_id,
-      values: castArray(value!).map((v) => v.toString()),
+      values: castArray(value).map(String),
     }));
 
 export const getUploadRequests = createSelector(

--- a/src/renderer/state/upload/selectors.ts
+++ b/src/renderer/state/upload/selectors.ts
@@ -471,7 +471,7 @@ export const getExtractedAnnotations = (
     .filter(({ value }) => value !== null && value !== "")
     .map(({ annotation_id, value }) => ({
       annotationId: annotation_id,
-      values: castArray(value).map((v) => v.toString()),
+      values: castArray(value!).map((v) => v.toString()),
     }));
 
 export const getUploadRequests = createSelector(

--- a/src/renderer/state/upload/selectors.ts
+++ b/src/renderer/state/upload/selectors.ts
@@ -464,26 +464,15 @@ export const getAnnotations = (
   return annotations;
 };
 
-export const getExtractedAnnotationsNotInTemplate = (
-  mxsMetadata: MXSResult,
-  templateAnnotationNames: Set<string>
+export const getExtractedAnnotations = (
+  mxsMetadata: MXSResult
 ): MMSAnnotationValueRequest[] =>
-  Object.entries(mxsMetadata).reduce(
-    (accum, [annotationName, { annotation_id, value }]) => {
-      if (
-        !templateAnnotationNames.has(annotationName) &&
-        value !== null &&
-        value !== ""
-      ) {
-        accum.push({
-          annotationId: annotation_id,
-          values: castArray(value).map((v) => v.toString()),
-        });
-      }
-      return accum;
-    },
-    [] as MMSAnnotationValueRequest[]
-  );
+  Object.values(mxsMetadata)
+    .filter(({ value }) => value !== null && value !== "")
+    .map(({ annotation_id, value }) => ({
+      annotationId: annotation_id,
+      values: castArray(value).map((v) => v.toString()),
+    }));
 
 export const getUploadRequests = createSelector(
   [
@@ -502,24 +491,21 @@ export const getUploadRequests = createSelector(
       throw new Error("Template has not been applied");
     }
 
-    const templateAnnotationNames = new Set(
-      template.annotations.map((a) => a.name)
-    );
-
     return Object.entries(uploads).map(([filePath, fileMetadata]) => {
-      const mxsMetadata = metadataExtractionState?.[filePath]?.metadata;
-      const extractedAnnotations = mxsMetadata
-        ? getExtractedAnnotationsNotInTemplate(
-            mxsMetadata,
-            templateAnnotationNames
-          )
-        : [];
+      // raw metadata
+      const mxsMetadata = metadataExtractionState?.[filePath]?.metadata ?? {};
+
+      const extractedAnnotations = getExtractedAnnotations(mxsMetadata);
 
       return {
         customMetadata: {
           annotations: [
-            ...getAnnotations(fileMetadata, template),
             ...extractedAnnotations,
+            // this omits what is already in MXS extracted metadata, and only adds whats missing from user
+            ...getAnnotations(
+              omit(fileMetadata, Object.keys(mxsMetadata)) as FileModel,
+              template
+            ),
           ],
           templateId: template.templateId,
         },

--- a/src/renderer/state/upload/selectors.ts
+++ b/src/renderer/state/upload/selectors.ts
@@ -26,6 +26,7 @@ import {
   PROGRAM_ANNOTATION_ID,
 } from "../../constants";
 import { ColumnType } from "../../services/labkey-client/types";
+import { MXSResult } from "../../services/metadata-extraction-service";
 import { UploadRequest } from "../../services/types";
 import { Duration } from "../../types";
 import { extensionToFileTypeMap } from "../../util";
@@ -41,6 +42,8 @@ import {
   getPlateBarcodeToPlates,
   getTextAnnotationTypeId,
 } from "../metadata/selectors";
+import { getMetadataExtractionState } from "../metadataExtraction/selectors";
+import { MetadataExtractionState } from "../metadataExtraction/types";
 import { getShouldBeInLocal } from "../selection/selectors";
 import { getCompleteAppliedTemplate } from "../template/selectors";
 import {
@@ -373,17 +376,9 @@ export const getAnnotations = (
     {}
   );
 
-  // Get the list of autofilled fields to exclude from upload
-  const autofilledFields = new Set(fileMetadata.autofilledFields || []);
-
   const customData = removeExcludedFields(fileMetadata);
   const annotations = Object.entries(customData).reduce(
     (annotationsAccum, [annotationName, value]) => {
-      // Skip autofilled fields - MXS will handle these during upload
-      if (autofilledFields.has(annotationName)) {
-        return annotationsAccum;
-      }
-
       const annotation = annotationNameToAnnotationMap[annotationName];
       if (annotation) {
         // Special case where no value for a boolean type is the same as
@@ -469,45 +464,90 @@ export const getAnnotations = (
   return annotations;
 };
 
+export const getExtractedAnnotationsNotInTemplate = (
+  mxsMetadata: MXSResult,
+  templateAnnotationNames: Set<string>
+): MMSAnnotationValueRequest[] =>
+  Object.entries(mxsMetadata).reduce(
+    (accum, [annotationName, { annotation_id, value }]) => {
+      if (
+        !templateAnnotationNames.has(annotationName) &&
+        value !== null &&
+        value !== undefined &&
+        value !== ""
+      ) {
+        accum.push({
+          annotationId: annotation_id,
+          values: castArray(value).map((v) => v.toString()),
+        });
+      }
+      return accum;
+    },
+    [] as MMSAnnotationValueRequest[]
+  );
+
 export const getUploadRequests = createSelector(
-  [getUpload, getCompleteAppliedTemplate, getShouldBeInLocal],
+  [
+    getUpload,
+    getCompleteAppliedTemplate,
+    getShouldBeInLocal,
+    getMetadataExtractionState,
+  ],
   (
     uploads: UploadStateBranch,
     template?: TemplateWithTypeNames,
-    ShouldBeInLocal?: boolean
+    ShouldBeInLocal?: boolean,
+    metadataExtractionState?: MetadataExtractionState
   ): UploadRequest[] => {
     if (!template) {
       throw new Error("Template has not been applied");
     }
 
-    return Object.entries(uploads).map(([filePath, fileMetadata]) => ({
-      customMetadata: {
-        annotations: getAnnotations(fileMetadata, template),
-        templateId: template.templateId,
-      },
-      file: {
-        disposition: "tape", // prevent czi -> ome.tiff conversions
-        fileType:
-          extensionToFileTypeMap[extname(filePath).toLowerCase()] ||
-          FileType.OTHER,
-        originalPath: filePath,
-        shouldBeInArchive: true,
-        shouldBeInLocal: ShouldBeInLocal,
-        uploadType: fileMetadata.uploadType,
-        // optional jss fields [fileId, customFileName]
-        ...(fileMetadata.fileId && { fileId: fileMetadata.fileId }),
-        ...(fileMetadata.customFileName && {
-          customFileName: fileMetadata.customFileName,
-        }),
-      },
-      // To support the current way of storing metadata in bob the blob, we continue to include
-      // wellIds in the microscopy block.
-      microscopy: {
-        ...(fileMetadata[AnnotationName.WELL]?.length && {
-          wellIds: fileMetadata[AnnotationName.WELL],
-        }),
-      },
-    }));
+    const templateAnnotationNames = new Set(
+      template.annotations.map((a) => a.name)
+    );
+
+    return Object.entries(uploads).map(([filePath, fileMetadata]) => {
+      const mxsMetadata = metadataExtractionState?.[filePath]?.metadata;
+      const extractedAnnotations = mxsMetadata
+        ? getExtractedAnnotationsNotInTemplate(
+            mxsMetadata,
+            templateAnnotationNames
+          )
+        : [];
+
+      return {
+        customMetadata: {
+          annotations: [
+            ...getAnnotations(fileMetadata, template),
+            ...extractedAnnotations,
+          ],
+          templateId: template.templateId,
+        },
+        file: {
+          disposition: "tape", // prevent czi -> ome.tiff conversions
+          fileType:
+            extensionToFileTypeMap[extname(filePath).toLowerCase()] ||
+            FileType.OTHER,
+          originalPath: filePath,
+          shouldBeInArchive: true,
+          shouldBeInLocal: ShouldBeInLocal,
+          uploadType: fileMetadata.uploadType,
+          // optional jss fields [fileId, customFileName]
+          ...(fileMetadata.fileId && { fileId: fileMetadata.fileId }),
+          ...(fileMetadata.customFileName && {
+            customFileName: fileMetadata.customFileName,
+          }),
+        },
+        // To support the current way of storing metadata in bob the blob, we continue to include
+        // wellIds in the microscopy block.
+        microscopy: {
+          ...(fileMetadata[AnnotationName.WELL]?.length && {
+            wellIds: fileMetadata[AnnotationName.WELL],
+          }),
+        },
+      };
+    });
   }
 );
 

--- a/src/renderer/state/upload/test/selectors.test.ts
+++ b/src/renderer/state/upload/test/selectors.test.ts
@@ -46,7 +46,7 @@ import {
   getUploadAsTableRows,
   getUploadValidationErrors,
   getAnnotations,
-  getExtractedAnnotationsNotInTemplate,
+  getExtractedAnnotations,
 } from "../selectors";
 import { FileType } from "../types";
 
@@ -1224,22 +1224,18 @@ describe("Upload selectors", () => {
     });
   });
 
-  describe("getExtractedAnnotationsNotInTemplate", () => {
-    const templateAnnotationNames = new Set(["Template Field"]);
-
-    it("should include extracted fields not in the template using MXS annotation_id", () => {
+  describe("getExtractedAnnotations", () => {
+    it("should include extracted fields using MXS annotation_id", () => {
       const mxsMetadata = {
-        "Non-Template Field": { annotation_id: 999, value: "extracted value" },
-        "Template Field": { annotation_id: 1, value: "template value" },
+        "Cell Line": { annotation_id: 999, value: "AICS-22" },
+        Duration: { annotation_id: 1, value: "3600" },
       };
 
-      const result = getExtractedAnnotationsNotInTemplate(
-        mxsMetadata,
-        templateAnnotationNames
-      );
+      const result = getExtractedAnnotations(mxsMetadata);
 
       expect(result).to.deep.equal([
-        { annotationId: 999, values: ["extracted value"] },
+        { annotationId: 999, values: ["AICS-22"] },
+        { annotationId: 1, values: ["3600"] },
       ]);
     });
 
@@ -1250,10 +1246,7 @@ describe("Upload selectors", () => {
         "Valid Field": { annotation_id: 12, value: "valid" },
       };
 
-      const result = getExtractedAnnotationsNotInTemplate(
-        mxsMetadata,
-        templateAnnotationNames
-      );
+      const result = getExtractedAnnotations(mxsMetadata);
 
       expect(result).to.deep.equal([{ annotationId: 12, values: ["valid"] }]);
     });

--- a/src/renderer/state/upload/test/selectors.test.ts
+++ b/src/renderer/state/upload/test/selectors.test.ts
@@ -46,6 +46,7 @@ import {
   getUploadAsTableRows,
   getUploadValidationErrors,
   getAnnotations,
+  getExtractedAnnotationsNotInTemplate,
 } from "../selectors";
 import { FileType } from "../types";
 
@@ -1201,6 +1202,60 @@ describe("Upload selectors", () => {
       const result = getAnnotations(fileMetadataBlank, appliedTemplate as any);
 
       expect(result).to.be.an("array").that.is.empty;
+    });
+
+    it("should include autofilled fields in upload annotations", () => {
+      const fileMetadataWithAutofill = {
+        "Test Annotation": ["autofilled value"],
+        autofilledFields: ["Test Annotation"],
+      } as any;
+
+      const result = getAnnotations(
+        fileMetadataWithAutofill,
+        appliedTemplate as any
+      );
+
+      expect(result).to.deep.equal([
+        {
+          annotationId: 1000,
+          values: ["autofilled value"],
+        },
+      ]);
+    });
+  });
+
+  describe("getExtractedAnnotationsNotInTemplate", () => {
+    const templateAnnotationNames = new Set(["Template Field"]);
+
+    it("should include extracted fields not in the template using MXS annotation_id", () => {
+      const mxsMetadata = {
+        "Non-Template Field": { annotation_id: 999, value: "extracted value" },
+        "Template Field": { annotation_id: 1, value: "template value" },
+      };
+
+      const result = getExtractedAnnotationsNotInTemplate(
+        mxsMetadata,
+        templateAnnotationNames
+      );
+
+      expect(result).to.deep.equal([
+        { annotationId: 999, values: ["extracted value"] },
+      ]);
+    });
+
+    it("should exclude fields with null or empty values", () => {
+      const mxsMetadata = {
+        "Null Field": { annotation_id: 10, value: null },
+        "Empty Field": { annotation_id: 11, value: "" },
+        "Valid Field": { annotation_id: 12, value: "valid" },
+      };
+
+      const result = getExtractedAnnotationsNotInTemplate(
+        mxsMetadata,
+        templateAnnotationNames
+      );
+
+      expect(result).to.deep.equal([{ annotationId: 12, values: ["valid"] }]);
     });
   });
 });


### PR DESCRIPTION
**Description**
this is the start of our design change to move away from automatic extractions on the backend and start to upload extracted metadata from the clients.

the metadata is still extracted by MXS, but the client calls MXS and we use the client to pass the data forwards to MMS.

**Changes**
- src/renderer/state/metadataExtraction/logics.ts: Identifies which annotations in template are `Duration` type, and converts metadata recieved from MXS (which is in ms) to make sure UI renders it correctly
- src/renderer/state/upload/selectors.ts: Removed exclusion of autofilled metadata, which we now include in the metadata sent to MMS. Merges all MXS extracted metadata with user entered
- src/renderer/state/upload/test/selectors.test.ts: test changes
- src/renderer/state/upload/reducer.ts: Comment change (this will change later again)


**Validation**
Tested with array of czi and nd2 images on staging- uploads show all metadata, user entered, and extracted, on FMS