### PR TITLE
Feature/support timelapse master

### DIFF
--- a/src/renderer/containers/Table/CustomCells/WellCell/index.tsx
+++ b/src/renderer/containers/Table/CustomCells/WellCell/index.tsx
@@ -40,6 +40,8 @@ export default function WellCell(props: CellProps<FileModel>) {
   const [selectedWells, setSelectedWells] = React.useState<AicsGridCell[]>([]);
   const isAutofilled =
     props.row.original.autofilledFields?.includes(AnnotationName.WELL) ?? false;
+  const isTimelapsemaster =
+    props.row.original["Is Timelapse Master File"]?.[0] === true;
   const associatedWells = props.row.original[AnnotationName.WELL] || [];
   const plateBarcode = props.row.original[AnnotationName.PLATE_BARCODE]?.[0];
   const imagingSessionName =
@@ -156,10 +158,13 @@ export default function WellCell(props: CellProps<FileModel>) {
       <DisplayCell
         {...props}
         value={wellLabels.sort()}
-        disabled={!wells?.[0].length}
+        disabled={!wells?.[0].length || isTimelapsemaster}
         onTabExit={() => setIsEditing(false)}
         onStartEditing={() =>
-          !isAutofilled && wells?.[0].length && setIsEditing(true)
+          !isAutofilled &&
+          !isTimelapsemaster &&
+          wells?.[0].length &&
+          setIsEditing(true)
         }
       />
       <Modal

--- a/src/renderer/state/upload/selectors.ts
+++ b/src/renderer/state/upload/selectors.ts
@@ -333,7 +333,10 @@ export const getUploadValidationErrors = createSelector(
               );
             }
           }
-          if (!annotationHasValueMap[AnnotationName.WELL]) {
+          if (
+            !annotationHasValueMap[AnnotationName.WELL] &&
+            !annotationHasValueMap["Is Timelapse Master File"]
+          ) {
             requiredAnnotationsThatDontHaveValues.push(AnnotationName.WELL);
           }
         }

--- a/src/renderer/state/upload/test/selectors.test.ts
+++ b/src/renderer/state/upload/test/selectors.test.ts
@@ -1057,6 +1057,51 @@ describe("Upload selectors", () => {
       ).to.be.true;
     });
 
+    it("does not add well error if row is a timelapse master file", () => {
+      const errors = getUploadValidationErrors({
+        ...nonEmptyStateForInitiatingUpload,
+        upload: getMockStateWithHistory({
+          foo: {
+            "Favorite Color": 1,
+            file: "foo",
+            key: "foo",
+            [AnnotationName.NOTES]: [],
+            [AnnotationName.PLATE_BARCODE]: ["1491201"],
+            [AnnotationName.WELL]: [],
+            [AnnotationName.PROGRAM]: ["foo"],
+            "Is Timelapse Master File": [true],
+          },
+        }),
+      });
+      expect(
+        errors.includes(
+          `"foo" is missing the following required annotations: ${AnnotationName.WELL}`
+        )
+      ).to.be.false;
+    });
+
+    it("still adds well error if Is Timelapse Master File True does not exist", () => {
+      const errors = getUploadValidationErrors({
+        ...nonEmptyStateForInitiatingUpload,
+        upload: getMockStateWithHistory({
+          foo: {
+            "Favorite Color": 1,
+            file: "foo",
+            key: "foo",
+            [AnnotationName.NOTES]: [],
+            [AnnotationName.PLATE_BARCODE]: ["1491201"],
+            [AnnotationName.WELL]: [],
+            [AnnotationName.PROGRAM]: ["foo"],
+          },
+        }),
+      });
+      expect(
+        errors.includes(
+          `"foo" is missing the following required annotations: ${AnnotationName.WELL}`
+        )
+      ).to.be.true;
+    });
+
     it("adds error if a row does not have a program annotation and is meant to", () => {
       const errors = getUploadValidationErrors({
         ...nonEmptyStateForInitiatingUpload,


### PR DESCRIPTION
### Description
ticket here: https://github.com/aics-int/aics-file-upload-app/issues/274?issue=aics-int%7Caics-file-upload-app%7C275

this is to support timelapse master files. When one is detected by MXS, disable well requirement on FUA

### Changes
**src/renderer/containers/Table/CustomCells/WellCell/index.tsx**

- WellCell disabled for timelapse master files

**src/renderer/state/upload/selectors.ts**

- waives well requirement for timelapse master files
