### PR TITLE
Remove 100 uploads history limit

### DIFF
--- a/src/renderer/containers/MyUploadsPage/index.tsx
+++ b/src/renderer/containers/MyUploadsPage/index.tsx
@@ -30,7 +30,7 @@ const styles = require("./styles.pcss");
  */
 export default function MyUploadsPage() {
   const dispatch = useDispatch();
-  const recentUploads = useSelector(getRecentUploads).slice(0, 100);
+  const recentUploads = useSelector(getRecentUploads);
   const requestsInProgress = useSelector(getRequestsInProgress);
   const isRequestingJobs = requestsInProgress.includes(AsyncRequest.GET_JOBS);
 


### PR DESCRIPTION
### Description
Made this change to limit uploads to 100 a while back, some users have complained about this change and said they needed to see more than 100 uploads at a time.

It looks like our top 2 users upload around 600 files a month so they may need this

Small change to remove the 100 upload limit
