### PR TITLE
Bugfix/upload mass editor bugs

### DIFF
--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -177,7 +177,7 @@ const stopCellDragLogic = createLogic({
       const columnId = cellAtDragStart.columnId;
       const rowIds = rows
         .map((row: UploadRowTableId) => row.id)
-        .filter((id) => !upload[id]?.autofilledFields?.includes(columnId));
+        .filter((id: any) => !upload[id]?.autofilledFields?.includes(columnId));
       const value = upload[cellAtDragStart.rowId][columnId];
       if (rowIds.length) {
         dispatch(updateUploadRows(rowIds, { [columnId]: value }));

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -173,10 +173,15 @@ const stopCellDragLogic = createLogic({
   ) => {
     const { cellAtDragStart, rows } = ctx;
     if (cellAtDragStart && rows?.length) {
-      const rowIds = rows.map((row: UploadRowTableId) => row.id);
       const upload = getUpload(getState());
-      const value = upload[cellAtDragStart.rowId][cellAtDragStart.columnId];
-      dispatch(updateUploadRows(rowIds, { [cellAtDragStart.columnId]: value }));
+      const columnId = cellAtDragStart.columnId;
+      const rowIds = rows
+        .map((row: UploadRowTableId) => row.id)
+        .filter((id) => !upload[id]?.autofilledFields?.includes(columnId));
+      const value = upload[cellAtDragStart.rowId][columnId];
+      if (rowIds.length) {
+        dispatch(updateUploadRows(rowIds, { [columnId]: value }));
+      }
     }
     done();
   },

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -106,9 +106,14 @@ const startMassEditLogic = createLogic({
       {}
     );
 
-    // make mass edit rows autofilled like regular ones
+    // grey out mass edit UI columns if rows are autofilled
+    // if any selected row is already autofilled
+    // user should not be able to mass edit on that row
+    // to avoid potentially overwriting extracted metadata.
     const selectedRowIds: string[] = action.payload;
     const upload = getUpload(getState());
+
+    // get set of autofilled fields that we should not mass edit
     const autofilledFieldSets = selectedRowIds.map(
       (id) => new Set<string>(upload[id]?.autofilledFields || [])
     );
@@ -117,6 +122,7 @@ const startMassEditLogic = createLogic({
         ...new Set(autofilledFieldSets.flatMap((set) => [...set])),
       ];
       if (setList.length) {
+        // disable mass edit for any fields in the set
         massEditRow.autofilledFields = setList;
       }
     }
@@ -175,10 +181,13 @@ const stopCellDragLogic = createLogic({
     if (cellAtDragStart && rows?.length) {
       const upload = getUpload(getState());
       const columnId = cellAtDragStart.columnId;
+      // get row ids that dont have autofill
       const rowIds = rows
         .map((row: UploadRowTableId) => row.id)
         .filter((id: any) => !upload[id]?.autofilledFields?.includes(columnId));
       const value = upload[cellAtDragStart.rowId][columnId];
+
+      // drag to copy protection against overwriting rows already autofilled by mxs
       if (rowIds.length) {
         dispatch(updateUploadRows(rowIds, { [columnId]: value }));
       }

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -98,13 +98,29 @@ const startMassEditLogic = createLogic({
       return;
     }
     const { annotations } = template;
-    const massEditRow = annotations.reduce(
+    const massEditRow: MassEditRow = annotations.reduce(
       (row, annotation) => ({
         ...row,
         [annotation.name]: [],
       }),
       {}
     );
+
+    // make mass edit rows autofilled like regular ones
+    const selectedRowIds: string[] = action.payload;
+    const upload = getUpload(getState());
+    const autofilledFieldSets = selectedRowIds.map(
+      (id) => new Set<string>(upload[id]?.autofilledFields || [])
+    );
+    if (autofilledFieldSets.length) {
+      const setList = [
+        ...new Set(autofilledFieldSets.flatMap((set) => [...set])),
+      ];
+      if (setList.length) {
+        massEditRow.autofilledFields = setList;
+      }
+    }
+
     next({
       ...action,
       payload: {

--- a/src/renderer/state/selection/test/logics.test.ts
+++ b/src/renderer/state/selection/test/logics.test.ts
@@ -163,6 +163,49 @@ describe("Selection logics", () => {
         selectedRowIds
       );
     });
+
+    it("greys a field in mass edit if any selected row has it autofilled", () => {
+      // Arrange
+      const selectedRowIds = ["1", "2", "3"];
+      const { store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        upload: getMockStateWithHistory({
+          "1": { file: "/path/1", autofilledFields: ["Favorite Color"] },
+          "2": {
+            file: "/path/2",
+            autofilledFields: ["Favorite Color", AnnotationName.WELL],
+          },
+          "3": { file: "/path/3" },
+        }),
+      });
+
+      // Act
+      store.dispatch(startMassEdit(selectedRowIds));
+
+      // Assert
+      expect(
+        getMassEditRow(store.getState())?.autofilledFields
+      ).to.have.members(["Favorite Color", AnnotationName.WELL]);
+    });
+
+    it("does not set autofilledFields if no selected rows have any", () => {
+      // Arrange
+      const selectedRowIds = ["1", "2"];
+      const { store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        upload: getMockStateWithHistory({
+          "1": { file: "/path/1" },
+          "2": { file: "/path/2" },
+        }),
+      });
+
+      // Act
+      store.dispatch(startMassEdit(selectedRowIds));
+
+      // Assert
+      expect(getMassEditRow(store.getState())?.autofilledFields).to.be
+        .undefined;
+    });
   });
 
   describe("applyMassEditLogic", () => {
@@ -242,6 +285,95 @@ describe("Selection logics", () => {
           })
         )
       ).to.be.true;
+    });
+
+    it("does not overwrite autofilled cells when dragging", async () => {
+      // Arrange
+      const uploadValue = "false";
+      const cellAtDragStart = {
+        rowId: "14",
+        columnId: "Is Aligned?",
+        rowIndex: 2,
+      };
+      const autofilledRowId = "9";
+      const nonAutofilledRowIds = ["21", "3", "18"];
+      const rowsSelectedForDragEvent = [
+        ...nonAutofilledRowIds,
+        autofilledRowId,
+      ].map((id, index) => ({ id, index }));
+      const { actions, logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        selection: {
+          ...mockSelection,
+          cellAtDragStart,
+          rowsSelectedForDragEvent,
+        },
+        upload: getMockStateWithHistory({
+          [cellAtDragStart.rowId]: {
+            file: "/some/path/source.txt",
+            [cellAtDragStart.columnId]: uploadValue,
+          },
+          [autofilledRowId]: {
+            file: "/some/path/autofilled.txt",
+            autofilledFields: [cellAtDragStart.columnId],
+          },
+        }),
+      });
+
+      // Act
+      store.dispatch(stopCellDrag());
+      await logicMiddleware.whenComplete();
+
+      // Assert - only non-autofilled rows receive the update
+      expect(
+        actions.includesMatch(
+          updateUploadRows(nonAutofilledRowIds, {
+            [cellAtDragStart.columnId]: uploadValue,
+          })
+        )
+      ).to.be.true;
+      expect(
+        actions.includesMatch(
+          updateUploadRows([...nonAutofilledRowIds, autofilledRowId], {
+            [cellAtDragStart.columnId]: uploadValue,
+          })
+        )
+      ).to.be.false;
+    });
+
+    it("does not dispatch if all dragged rows are autofilled", async () => {
+      // Arrange
+      const cellAtDragStart = {
+        rowId: "14",
+        columnId: "Is Aligned?",
+        rowIndex: 2,
+      };
+      const rowsSelectedForDragEvent = [{ id: "9", index: 0 }];
+      const { actions, logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        selection: {
+          ...mockSelection,
+          cellAtDragStart,
+          rowsSelectedForDragEvent,
+        },
+        upload: getMockStateWithHistory({
+          [cellAtDragStart.rowId]: {
+            file: "/some/path/source.txt",
+            [cellAtDragStart.columnId]: "false",
+          },
+          "9": {
+            file: "/some/path/autofilled.txt",
+            autofilledFields: [cellAtDragStart.columnId],
+          },
+        }),
+      });
+
+      // Act
+      store.dispatch(stopCellDrag());
+      await logicMiddleware.whenComplete();
+
+      // Assert - no updateUploadRows dispatched since the only dragged row was autofilled
+      expect(actions.includesType(updateUploadRows([], {}).type)).to.be.false;
     });
   });
 });

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -410,7 +410,6 @@ const updateUploadLogic = createLogic({
       const currentMassEditRow = getMassEditRow(deps.getState());
       if (currentMassEditRow) {
         // in mass edit, grey the well column once plate data is available
-        // the actual per-file well autofill happens on Apply
         const existingAutofilledFields =
           currentMassEditRow.autofilledFields || [];
         if (!existingAutofilledFields.includes(AnnotationName.WELL)) {

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -478,6 +478,28 @@ const updateUploadLogic = createLogic({
 });
 
 const updateUploadRowsLogic = createLogic({
+  process: async (
+    deps: ReduxLogicProcessDependenciesWithAction<UpdateUploadRowsAction>,
+    dispatch: ReduxLogicNextCb,
+    done: ReduxLogicDoneCb
+  ) => {
+    const { metadataUpdate, uploadKeys } = deps.action.payload;
+    const plateBarcode = (metadataUpdate as Partial<FileModel>)[
+      AnnotationName.PLATE_BARCODE
+    ]?.[0];
+
+    if (plateBarcode) {
+      for (const fileKey of uploadKeys) {
+        dispatch(
+          updateUpload(fileKey, {
+            [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+          })
+        );
+      }
+    }
+
+    done();
+  },
   transform: (
     {
       action,

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -407,30 +407,49 @@ const updateUploadLogic = createLogic({
         dispatch(setPlateBarcodeToPlates(updatedPlateBarcodeToPlates));
       }
 
-      // autoselect well if row and col data available from mxs
-      const fileKey = deps.action.payload.key;
-      const mxsData = deps.getState().metadataExtraction[fileKey]?.metadata;
-      const rowValue = mxsData?.["Row"]?.value;
-      const colValue = mxsData?.["Column"]?.value;
-
-      if (rowValue !== undefined && colValue !== undefined) {
-        // row and col are 1-indexed in metadata, convert to 0-indexed
-        const row = Number(rowValue) - 1;
-        const col = Number(colValue) - 1;
-        const plates = updatedPlateBarcodeToPlates[plateBarcode];
-        // this should match the logic in WellCell
-        const imagingSessionName = upload[AnnotationName.IMAGING_SESSION]?.[0];
-        const plate = plates?.find((p) =>
-          imagingSessionName ? p.name === imagingSessionName : !p.name
-        );
-        const well = plate?.wells.find((w) => w.row === row && w.col === col);
-        if (well) {
+      const currentMassEditRow = getMassEditRow(deps.getState());
+      if (currentMassEditRow) {
+        // in mass edit, grey the well column once plate data is available
+        // the actual per-file well autofill happens on Apply
+        const existingAutofilledFields =
+          currentMassEditRow.autofilledFields || [];
+        if (!existingAutofilledFields.includes(AnnotationName.WELL)) {
           dispatch(
-            updateUpload(fileKey, {
-              [AnnotationName.WELL]: [well.wellId],
-              autofilledFields: [AnnotationName.WELL],
+            updateMassEditRow({
+              autofilledFields: [
+                ...existingAutofilledFields,
+                AnnotationName.WELL,
+              ],
             })
           );
+        }
+      } else {
+        // autoselect well if row and col data available from mxs
+        const fileKey = deps.action.payload.key;
+        const mxsData = deps.getState().metadataExtraction[fileKey]?.metadata;
+        const rowValue = mxsData?.["Row"]?.value;
+        const colValue = mxsData?.["Column"]?.value;
+
+        if (rowValue !== undefined && colValue !== undefined) {
+          // row and col are 1-indexed in metadata, convert to 0-indexed
+          const row = Number(rowValue) - 1;
+          const col = Number(colValue) - 1;
+          const plates = updatedPlateBarcodeToPlates[plateBarcode];
+          // this should match the logic in WellCell
+          const imagingSessionName =
+            upload[AnnotationName.IMAGING_SESSION]?.[0];
+          const plate = plates?.find((p) =>
+            imagingSessionName ? p.name === imagingSessionName : !p.name
+          );
+          const well = plate?.wells.find((w) => w.row === row && w.col === col);
+          if (well) {
+            dispatch(
+              updateUpload(fileKey, {
+                [AnnotationName.WELL]: [well.wellId],
+                autofilledFields: [AnnotationName.WELL],
+              })
+            );
+          }
         }
       }
     }

--- a/src/renderer/state/upload/test/logics.test.ts
+++ b/src/renderer/state/upload/test/logics.test.ts
@@ -21,6 +21,7 @@ import { setPlateBarcodeToPlates } from "../../metadata/actions";
 import { SET_PLATE_BARCODE_TO_PLATES } from "../../metadata/constants";
 import { getPlateBarcodeToPlates } from "../../metadata/selectors";
 import { resetUpload } from "../../route/actions";
+import { updateMassEditRow } from "../../selection/actions";
 import { setAppliedTemplate } from "../../template/actions";
 import {
   createMockReduxStore,
@@ -41,6 +42,7 @@ import {
   mockTemplateStateBranch,
   mockTemplateWithManyValues,
   mockTextAnnotation,
+  mockSelection,
   mockWellUpload,
   nonEmptyStateForInitiatingUpload,
 } from "../../test/mocks";
@@ -1027,6 +1029,64 @@ describe("Upload logics", () => {
       expect(
         getUpload(store.getState())[uploadRowKey][AnnotationName.WELL]
       ).to.deep.equal([]);
+    });
+
+    it("greys well column in mass edit after plate data is fetched", async () => {
+      // Arrange
+      const plateBarcode = "490109230";
+      const { actions, store, logicMiddleware } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        selection: {
+          ...mockSelection,
+          massEditRow: { [AnnotationName.PLATE_BARCODE]: [plateBarcode] },
+          rowsSelectedForMassEdit: [uploadRowKey],
+        },
+        template: {
+          ...mockTemplateStateBranch,
+          appliedTemplate: {
+            ...mockTemplateWithManyValues,
+            annotations: [mockTextAnnotation],
+          },
+        },
+        upload: getMockStateWithHistory({
+          [uploadRowKey]: {
+            [mockTextAnnotation.name]: [],
+            file: "/path/to/file3",
+            [AnnotationName.NOTES]: [],
+            templateId: 8,
+            [AnnotationName.WELL]: [],
+          },
+        }),
+      });
+      labkeyClient.findImagingSessionsByPlateBarcode.resolves([]);
+      mmsClient.getPlate.resolves({
+        plate: {
+          barcode: "",
+          comments: "",
+          plateGeometryId: 8,
+          plateId: 14,
+          plateStatusId: 3,
+          ...mockAuditInfo,
+        },
+        wells: [],
+      });
+
+      // Act
+      store.dispatch(
+        updateUpload(uploadRowKey, {
+          [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+        })
+      );
+      await logicMiddleware.whenComplete();
+
+      // Assert - mass edit row gets WELL added to autofilledFields
+      expect(
+        actions.includesMatch(
+          updateMassEditRow({
+            autofilledFields: [AnnotationName.WELL],
+          })
+        )
+      ).to.be.true;
     });
 
     it("queries for plate barcode without imaging session if none found", async () => {


### PR DESCRIPTION
###  Description                                                                                                                                                     
This is a set of fixes to make the annotation mass editor behave consistently with annotating individual rows in the upload template.                                                        
                                                                                                                                                                  
Previously, entering a plate barcode in the mass editor didn't trigger well autofill per file.

additionally, using the mass edit feature or dragging to copy values down a column could overwrite cells that had been autofilled by MXS.                                        
                                                                                                                                                                  
### Changes   
**src/renderer/state/selection/logics.ts**                                                                                                                         
Main changes here is to protect against editing already autofilled rows when drag and dropping or using mass edit UI to change multiple rows in a column.

- disable mass edit if a selected row has already been autofilled                     
- drag to copy skips autofilled rows                

**src/renderer/state/upload/logics.ts**
changes here are for the well autofill

- fix plate barcode not triggering well autofill on re-selection, now autofills the well 
                                                                                                                                                                                                                                                                                          
### Validation                                                                                                                                                      
                                                                                                                                                                  

- tested with czi files that have row/col metadata from MXS. barcodes entered in both single-row and mass edit correctly grey and autofill the well column.      

- dragging over autofilled rows leaves them untouched.