### PR TITLE
Fix CellDragLogic to not overwrite autofilled cells

### DIFF
--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -160,7 +160,7 @@ const stopCellDragLogic = createLogic({
       const upload = getUpload(getState());
       const columnId = cellAtDragStart.columnId;
       // get row ids that dont have autofill
-      const rowIds = rows
+      const notAutofilledRowIds = rows
         .map((row: UploadRowTableId) => row.id)
         .filter(
           (id: string) => !upload[id]?.autofilledFields?.includes(columnId)
@@ -168,8 +168,8 @@ const stopCellDragLogic = createLogic({
       const value = upload[cellAtDragStart.rowId][columnId];
 
       // drag to copy protection against overwriting rows already autofilled by mxs
-      if (rowIds.length) {
-        dispatch(updateUploadRows(rowIds, { [columnId]: value }));
+      if (notAutofilledRowIds.length) {
+        dispatch(updateUploadRows(notAutofilledRowIds, { [columnId]: value }));
       }
     }
     done();

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -157,10 +157,18 @@ const stopCellDragLogic = createLogic({
   ) => {
     const { cellAtDragStart, rows } = ctx;
     if (cellAtDragStart && rows?.length) {
-      const rowIds = rows.map((row: UploadRowTableId) => row.id);
       const upload = getUpload(getState());
-      const value = upload[cellAtDragStart.rowId][cellAtDragStart.columnId];
-      dispatch(updateUploadRows(rowIds, { [cellAtDragStart.columnId]: value }));
+      const columnId = cellAtDragStart.columnId;
+      // get row ids that dont have autofill
+      const rowIds = rows
+        .map((row: UploadRowTableId) => row.id)
+        .filter((id: any) => !upload[id]?.autofilledFields?.includes(columnId));
+      const value = upload[cellAtDragStart.rowId][columnId];
+
+      // drag to copy protection against overwriting rows already autofilled by mxs
+      if (rowIds.length) {
+        dispatch(updateUploadRows(rowIds, { [columnId]: value }));
+      }
     }
     done();
   },

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -162,7 +162,9 @@ const stopCellDragLogic = createLogic({
       // get row ids that dont have autofill
       const rowIds = rows
         .map((row: UploadRowTableId) => row.id)
-        .filter((id: any) => !upload[id]?.autofilledFields?.includes(columnId));
+        .filter(
+          (id: string) => !upload[id]?.autofilledFields?.includes(columnId)
+        );
       const value = upload[cellAtDragStart.rowId][columnId];
 
       // drag to copy protection against overwriting rows already autofilled by mxs

--- a/src/renderer/state/selection/test/logics.test.ts
+++ b/src/renderer/state/selection/test/logics.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../../test/mocks";
 import { Page } from "../../types";
 import { updateUploadRows } from "../../upload/actions";
+import { UPDATE_UPLOAD_ROWS } from "../../upload/constants";
 import { getUpload } from "../../upload/selectors";
 import { applyMassEdit, startMassEdit, stopCellDrag } from "../actions";
 import { getMassEditRow, getRowsSelectedForMassEdit } from "../selectors";
@@ -242,6 +243,98 @@ describe("Selection logics", () => {
           })
         )
       ).to.be.true;
+    });
+
+    it("excludes autofilled rows from update", async () => {
+      // Arrange
+      const uploadValue = "false";
+      const columnId = "Is Aligned?";
+      const autofilledRowId = "9";
+      const nonAutofilledRowIds = ["21", "3", "18"];
+      const rowsSelectedForDragEvent = [
+        ...nonAutofilledRowIds,
+        autofilledRowId,
+      ].map((id, index) => ({ id, index }));
+      const cellAtDragStart = { rowId: "14", columnId, rowIndex: 2 };
+      const uploadState: Record<string, any> = {
+        [cellAtDragStart.rowId]: {
+          file: "/some/path/to/a/file.txt",
+          [columnId]: uploadValue,
+        },
+        [autofilledRowId]: {
+          file: "/some/path/to/autofilled.txt",
+          autofilledFields: [columnId],
+        },
+      };
+      nonAutofilledRowIds.forEach((id) => {
+        uploadState[id] = { file: `/some/path/${id}.txt` };
+      });
+      const { actions, logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        selection: {
+          ...mockSelection,
+          cellAtDragStart,
+          rowsSelectedForDragEvent,
+        },
+        upload: getMockStateWithHistory(uploadState),
+      });
+
+      // Act
+      store.dispatch(stopCellDrag());
+      await logicMiddleware.whenComplete();
+
+      // Assert
+      expect(
+        actions.includesMatch(
+          updateUploadRows(nonAutofilledRowIds, { [columnId]: uploadValue })
+        )
+      ).to.be.true;
+      expect(
+        actions.includesMatch(
+          updateUploadRows([...nonAutofilledRowIds, autofilledRowId], {
+            [columnId]: uploadValue,
+          })
+        )
+      ).to.be.false;
+    });
+
+    it("does not dispatch update if all selected rows are autofilled", async () => {
+      // Arrange
+      const columnId = "Is Aligned?";
+      const rowIds = ["21", "3"];
+      const rowsSelectedForDragEvent = rowIds.map((id, index) => ({
+        id,
+        index,
+      }));
+      const cellAtDragStart = { rowId: "14", columnId, rowIndex: 2 };
+      const uploadState: Record<string, any> = {
+        [cellAtDragStart.rowId]: {
+          file: "/some/path/to/a/file.txt",
+          [columnId]: "false",
+        },
+      };
+      rowIds.forEach((id) => {
+        uploadState[id] = {
+          file: `/some/path/${id}.txt`,
+          autofilledFields: [columnId],
+        };
+      });
+      const { actions, logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        selection: {
+          ...mockSelection,
+          cellAtDragStart,
+          rowsSelectedForDragEvent,
+        },
+        upload: getMockStateWithHistory(uploadState),
+      });
+
+      // Act
+      store.dispatch(stopCellDrag());
+      await logicMiddleware.whenComplete();
+
+      // Assert
+      expect(actions.includesType(UPDATE_UPLOAD_ROWS)).to.be.false;
     });
   });
 });

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -478,6 +478,28 @@ const updateUploadLogic = createLogic({
 });
 
 const updateUploadRowsLogic = createLogic({
+  process: async (
+    deps: ReduxLogicProcessDependenciesWithAction<UpdateUploadRowsAction>,
+    dispatch: ReduxLogicNextCb,
+    done: ReduxLogicDoneCb
+  ) => {
+    const { metadataUpdate, uploadKeys } = deps.action.payload;
+    const plateBarcode = (metadataUpdate as Partial<FileModel>)[
+      AnnotationName.PLATE_BARCODE
+    ]?.[0];
+
+    if (plateBarcode) {
+      for (const fileKey of uploadKeys) {
+        dispatch(
+          updateUpload(fileKey, {
+            [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+          })
+        );
+      }
+    }
+
+    done();
+  },
   transform: (
     {
       action,

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -484,12 +484,16 @@ const updateUploadRowsLogic = createLogic({
     done: ReduxLogicDoneCb
   ) => {
     const { metadataUpdate, uploadKeys } = deps.action.payload;
+
+    // checks whether the drag and drop update contains plate barcode
     const plateBarcode = (metadataUpdate as Partial<FileModel>)[
       AnnotationName.PLATE_BARCODE
-    ]?.[0];
+    ]?.[0]; // update contains plate barcode value, or undefined if no plateBarcode value
 
     if (plateBarcode) {
       for (const fileKey of uploadKeys) {
+        // dispatch update to plate barcode for each row
+        // which will trigger well autofill
         dispatch(
           updateUpload(fileKey, {
             [AnnotationName.PLATE_BARCODE]: [plateBarcode],

--- a/src/renderer/state/upload/test/logics.test.ts
+++ b/src/renderer/state/upload/test/logics.test.ts
@@ -1200,6 +1200,54 @@ describe("Upload logics", () => {
       const upload = getUpload(store.getState());
       expect(upload[uploadRowKey]["Birth Date"][0]).to.be.a("Date");
     });
+
+    it("dispatches individual updateUpload per row when plate barcode is updated", async () => {
+      // arrange
+      const plateBarcode = "3500004832";
+      const uploadRowKey1 = "/path/to/file1";
+      const uploadRowKey2 = "/path/to/file2";
+
+      labkeyClient.findImagingSessionsByPlateBarcode.resolves([]);
+      mmsClient.getPlate.resolves({
+        plate: {
+          barcode: plateBarcode,
+          comments: "",
+          plateGeometryId: 8,
+          plateId: 14,
+          plateStatusId: 3,
+          ...mockAuditInfo,
+        },
+        wells: [],
+      });
+
+      const { logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        upload: getMockStateWithHistory({
+          [uploadRowKey1]: { file: uploadRowKey1 },
+          [uploadRowKey2]: { file: uploadRowKey2 },
+        }),
+      });
+
+      // act
+      store.dispatch(
+        updateUploadRows([uploadRowKey1, uploadRowKey2], {
+          [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+        })
+      );
+      await logicMiddleware.whenComplete();
+
+      // assert - updateUploadLogic ran for each row, triggering imaging session lookup per row
+      expect(labkeyClient.findImagingSessionsByPlateBarcode.callCount).to.equal(
+        2
+      );
+      const upload = getUpload(store.getState());
+      expect(upload[uploadRowKey1][AnnotationName.PLATE_BARCODE]).to.deep.equal(
+        [plateBarcode]
+      );
+      expect(upload[uploadRowKey2][AnnotationName.PLATE_BARCODE]).to.deep.equal(
+        [plateBarcode]
+      );
+    });
   });
   describe("saveUploadDraftLogic", () => {
     it("shows save dialog and does not dispatch saveUploadDraftSuccess if user cancels save", async () => {


### PR DESCRIPTION
This is a subset of these changes:
https://github.com/aics-int/aics-file-upload-app/pull/280

Plan for now is to hold off on mass editor changes. Autofill feature has made this confusing/ux flow weird so until we can talk to some users and get clarification from UX I am only releasing the drag and drop changes

### Changes

**src/renderer/state/selection/logics.ts**
protect against editing already autofilled rows when drag and dropping to change multiple rows in a column.