### PR TITLE
Convert osx paths to vast path

### DIFF
--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -21,7 +21,6 @@ import { addUploadFiles, updateUploadRows } from "../upload/actions";
 import { getUpload } from "../upload/selectors";
 import { batchActions } from "../util";
 
-
 import {
   APPLY_MASS_EDIT,
   LOAD_FILES,

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -2,6 +2,7 @@ import { createLogic } from "redux-logic";
 
 import { AnnotationName } from "../../constants";
 import type { UploadType } from "../../types";
+import { convertToVastPath } from "../../util";
 import { setAlert, startLoading, stopLoading } from "../feedback/actions";
 import { getBooleanAnnotationTypeId } from "../metadata/selectors";
 import { getAppliedTemplate } from "../template/selectors";
@@ -19,6 +20,7 @@ import {
 import { addUploadFiles, updateUploadRows } from "../upload/actions";
 import { getUpload } from "../upload/selectors";
 import { batchActions } from "../util";
+
 
 import {
   APPLY_MASS_EDIT,
@@ -58,10 +60,14 @@ const loadFilesLogic = createLogic({
           action.payload.map((item: any) => {
             if (typeof item === "string") {
               // If the item is a string, it's a path to a file on disk, and came from the 'Open File' dialog.'
-              return { file: item, uploadType };
+              return { file: convertToVastPath(item), uploadType };
             } else {
               // If the item is an object, it's a manually entered file name and path from our dev feature.'
-              return { file: item.path, uploadType, customFileName: item.name };
+              return {
+                file: convertToVastPath(item.path),
+                uploadType,
+                customFileName: item.name,
+              };
             }
           })
         )

--- a/src/renderer/state/selection/test/logics.test.ts
+++ b/src/renderer/state/selection/test/logics.test.ts
@@ -19,6 +19,7 @@ import {
   mockState,
   nonEmptyStateForInitiatingUpload,
 } from "../../test/mocks";
+import { AlertType } from "../../types";
 import { Page } from "../../types";
 import { updateUploadRows } from "../../upload/actions";
 import { UPDATE_UPLOAD_ROWS } from "../../upload/constants";
@@ -126,6 +127,24 @@ describe("Selection logics", () => {
       // after
       await logicMiddleware.whenComplete();
       expect(feedback.selectors.getIsLoading(store.getState())).to.equal(false);
+    });
+
+    it("sets an error alert when a non-VAST path is selected", async () => {
+      const { logicMiddleware, store } = createMockReduxStore(mockState);
+
+      store.dispatch(selections.actions.selectUploadType(UploadType.File));
+      store.dispatch(
+        selections.actions.loadFiles(["/Users/brian/Desktop/not_vast.czi"])
+      );
+
+      await logicMiddleware.whenComplete();
+      const alert = feedback.selectors.getAlert(store.getState());
+      expect(alert).to.not.be.undefined;
+      expect(alert?.type).to.equal(AlertType.ERROR);
+      expect(alert?.message).to.include(
+        "You must select files that are on VAST"
+      );
+      expect(getUpload(store.getState())).to.be.empty;
     });
 
     it("should stop loading on error", async () => {

--- a/src/renderer/state/selection/test/logics.test.ts
+++ b/src/renderer/state/selection/test/logics.test.ts
@@ -33,6 +33,7 @@ describe("Selection logics", () => {
   const FOLDER_NAME = "a_directory";
   const FILE_FULL_PATH = resolve(__dirname, TEST_FILES_DIR, FILE_NAME);
   const FOLDER_FULL_PATH = resolve(__dirname, TEST_FILES_DIR, FOLDER_NAME);
+  const VAST_FILE_PATH = "/allen/aics/test/cells.txt";
 
   let mmsClient: SinonStubbedInstance<MetadataManagementService>;
 
@@ -80,7 +81,7 @@ describe("Selection logics", () => {
 
       // apply
       store.dispatch(selections.actions.selectUploadType(UploadType.File));
-      store.dispatch(selections.actions.loadFiles([FILE_FULL_PATH]));
+      store.dispatch(selections.actions.loadFiles([VAST_FILE_PATH]));
 
       // after
       await logicMiddleware.whenComplete();
@@ -88,7 +89,7 @@ describe("Selection logics", () => {
 
       expect(Object.keys(upload)).to.be.lengthOf(1);
       const file = upload[Object.keys(upload)[0]];
-      expect(file.file).to.equal(FILE_FULL_PATH);
+      expect(file.file).to.equal(VAST_FILE_PATH);
     });
 
     it("sets files up for upload, using custom filename", async () => {
@@ -100,7 +101,7 @@ describe("Selection logics", () => {
       // apply
       store.dispatch(selections.actions.selectUploadType(UploadType.File));
       store.dispatch(
-        selections.actions.loadFiles([{ path: FILE_FULL_PATH, name: "bla" }])
+        selections.actions.loadFiles([{ path: VAST_FILE_PATH, name: "bla" }])
       );
 
       // after
@@ -109,7 +110,7 @@ describe("Selection logics", () => {
 
       expect(Object.keys(upload)).to.be.lengthOf(1);
       const file = upload[Object.keys(upload)[0]];
-      expect(file.file).to.equal(FILE_FULL_PATH);
+      expect(file.file).to.equal(VAST_FILE_PATH);
       expect(file.customFileName).to.equal("bla");
     });
 

--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -36,6 +36,22 @@ const canUserRead = async (filePath: string): Promise<boolean> => {
 };
 
 /**
+ * Converts an osx mount path to a VAST path starting with /allen.
+ * removes any prefix before /allen (ex: /Volumes/allen/... -> /allen/...).
+ * Throws an error if /allen is not found in the path.
+ */
+export function convertToVastPath(filePath: string): string {
+  const VAST_PREFIX = "/allen";
+  const allenIndex = filePath.toLowerCase().indexOf(VAST_PREFIX);
+
+  if (allenIndex === -1) {
+    throw new Error("You must select files that are on VAST");
+  }
+
+  return filePath.slice(allenIndex);
+}
+
+/**
  * Takes a list of file paths and checks to see if they can be read and if they match
  *  the given UploadType.
  */

--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -41,7 +41,7 @@ const canUserRead = async (filePath: string): Promise<boolean> => {
  * Throws an error if /allen is not found in the path.
  */
 export function convertToVastPath(filePath: string): string {
-  const VAST_PREFIX = "/allen";
+  const VAST_PREFIX = "/allen/";
   const allenIndex = filePath.toLowerCase().indexOf(VAST_PREFIX);
 
   if (allenIndex === -1) {

--- a/src/renderer/util/test/index.test.ts
+++ b/src/renderer/util/test/index.test.ts
@@ -8,6 +8,7 @@ import * as rimraf from "rimraf";
 import { restore, SinonStub, stub } from "sinon";
 
 import {
+  convertToVastPath,
   getDirectorySize,
   getPowerOf1000,
   handleFileSelection,
@@ -73,6 +74,38 @@ describe("General utilities", () => {
     });
     it("returns 1 if input is 999999", () => {
       expect(getPowerOf1000(999999)).to.equal(1);
+    });
+  });
+
+  describe("convertToVastPath", () => {
+    it("returns path unchanged if it already starts with /allen", () => {
+      expect(convertToVastPath("/allen/aics/test.czi")).to.equal(
+        "/allen/aics/test.czi"
+      );
+    });
+
+    it("removes OSX /Volumes prefix to produce a VAST path", () => {
+      expect(convertToVastPath("/Volumes/allen/aics/test.czi")).to.equal(
+        "/allen/aics/test.czi"
+      );
+    });
+
+    it("handles Windows-style double-slash prefix", () => {
+      expect(convertToVastPath("//allen/aics/test.czi")).to.equal(
+        "/allen/aics/test.czi"
+      );
+    });
+
+    it("throws 'You must select files that are on VAST' when /allen is absent", () => {
+      expect(() => convertToVastPath("/abc/cde/xyz/test.czi")).to.throw(
+        "You must select files that are on VAST"
+      );
+    });
+
+    it("throws when path has no recognizable VAST mount", () => {
+      expect(() => convertToVastPath("/Users/brian/Desktop/test.czi")).to.throw(
+        "You must select files that are on VAST"
+      );
     });
   });
 


### PR DESCRIPTION
### Overview
For this ticket https://github.com/aics-int/aics-file-upload-app/issues/284

We traditionally converted osx mount paths in FSS, this causes issues since this conversion needs to happen for MXS as well.

Instead of having this in multiple places on the backend, we decided to move osx mount conversion to the clients- so that paths are normalized to a vast path before entering the backend.

### Changes

src/renderer/util/index.ts: converts paths to vast paths. bit differently than in [fss here](https://github.com/aics-int/file-storage-service/pull/560). Should work even if user mounts VAST not in the standard location in our confluence docs.

src/renderer/state/selection/logics.ts: uses conversion method to convert paths after file selection

src/renderer/util/test/index.test.ts: some tests
