### PR TITLE
Mass edit Imaging Session fix

### DIFF
--- a/src/renderer/containers/CustomDataTable/selectors.tsx
+++ b/src/renderer/containers/CustomDataTable/selectors.tsx
@@ -159,10 +159,6 @@ const METADATA_COLUMN: CustomColumn = {
 // cause downstream effects like reseting user adjusted
 // column widths for selectors that rely on upload state
 // changes
-// Names of annotations rendered by the dedicated PLATE_RELATED_COLUMNS above.
-// Templates may also include these as regular annotations; rendering both would
-// create duplicate react-table columns (which throws) and break editing for
-// fields like "Imaging Session", so we let the dedicated columns win.
 const PLATE_RELATED_COLUMN_NAMES: ReadonlySet<string> = new Set(
   PLATE_RELATED_COLUMNS.map((column) => column.accessor as string)
 );

--- a/src/renderer/containers/CustomDataTable/selectors.tsx
+++ b/src/renderer/containers/CustomDataTable/selectors.tsx
@@ -159,6 +159,14 @@ const METADATA_COLUMN: CustomColumn = {
 // cause downstream effects like reseting user adjusted
 // column widths for selectors that rely on upload state
 // changes
+// Names of annotations rendered by the dedicated PLATE_RELATED_COLUMNS above.
+// Templates may also include these as regular annotations; rendering both would
+// create duplicate react-table columns (which throws) and break editing for
+// fields like "Imaging Session", so we let the dedicated columns win.
+const PLATE_RELATED_COLUMN_NAMES: ReadonlySet<string> = new Set(
+  PLATE_RELATED_COLUMNS.map((column) => column.accessor as string)
+);
+
 export const getTemplateColumnsForTable = createSelector(
   [getAnnotationTypes, getAppliedTemplate],
   (annotationTypes, template): CustomColumn[] => {
@@ -169,6 +177,9 @@ export const getTemplateColumnsForTable = createSelector(
     return [
       ...PLATE_RELATED_COLUMNS,
       ...template.annotations
+        .filter(
+          (annotation) => !PLATE_RELATED_COLUMN_NAMES.has(annotation.name)
+        )
         .sort((a, b) => a.orderIndex - b.orderIndex)
         .map((annotation) => {
           const type = annotationTypes.find(

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -21,7 +21,6 @@ import { addUploadFiles, updateUploadRows } from "../upload/actions";
 import { getUpload } from "../upload/selectors";
 import { batchActions } from "../util";
 
-
 import {
   APPLY_MASS_EDIT,
   LOAD_FILES,

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -491,12 +491,25 @@ const updateUploadRowsLogic = createLogic({
     ]?.[0]; // update contains plate barcode value, or undefined if no plateBarcode value
 
     if (plateBarcode) {
+      // Preserve any imaging session / well provided in the same update (e.g.
+      // a mass edit) so the plate barcode re-dispatch below does not wipe them
+      // out via the UPDATE_UPLOAD reset logic.
+      const imagingSession = (metadataUpdate as Partial<FileModel>)[
+        AnnotationName.IMAGING_SESSION
+      ];
+      const well = (metadataUpdate as Partial<FileModel>)[AnnotationName.WELL];
       for (const fileKey of uploadKeys) {
         // dispatch update to plate barcode for each row
         // which will trigger well autofill
         dispatch(
           updateUpload(fileKey, {
             [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+            ...(imagingSession !== undefined && {
+              [AnnotationName.IMAGING_SESSION]: imagingSession,
+            }),
+            ...(well !== undefined && {
+              [AnnotationName.WELL]: well,
+            }),
           })
         );
       }

--- a/src/renderer/state/upload/reducer.ts
+++ b/src/renderer/state/upload/reducer.ts
@@ -69,17 +69,20 @@ const actionToConfigMap: TypeToDescriptionMap<UploadStateBranch> = {
 
       let { upload } = action.payload;
       const modifiedAnnotations = Object.keys(upload);
-      // Reset Imaging Session and Well on Plate Barcode changes
+      // Reset Imaging Session and Well on Plate Barcode changes, unless a new
+      // value is provided in the same update (e.g. a mass edit applying a
+      // plate barcode and imaging session together). Spreading `upload` last
+      // lets explicitly provided values win over the reset defaults.
       if (modifiedAnnotations.includes(AnnotationName.PLATE_BARCODE)) {
         upload = {
-          ...upload,
           [AnnotationName.IMAGING_SESSION]: [],
           [AnnotationName.WELL]: [],
+          ...upload,
         };
       } else if (modifiedAnnotations.includes(AnnotationName.IMAGING_SESSION)) {
         upload = {
-          ...upload,
           [AnnotationName.WELL]: [],
+          ...upload,
         };
       }
 

--- a/src/renderer/state/upload/test/logics.test.ts
+++ b/src/renderer/state/upload/test/logics.test.ts
@@ -1248,6 +1248,55 @@ describe("Upload logics", () => {
         [plateBarcode]
       );
     });
+
+    it("preserves imaging session when applied alongside plate barcode", async () => {
+      // arrange - reproduces the mass edit case where a plate barcode and an
+      // imaging session are applied to rows together (issue #290)
+      const plateBarcode = "3500004832";
+      const imagingSession = "imaging session 9";
+      const uploadRowKey1 = "/path/to/file1";
+      const uploadRowKey2 = "/path/to/file2";
+
+      labkeyClient.findImagingSessionsByPlateBarcode.resolves([]);
+      mmsClient.getPlate.resolves({
+        plate: {
+          barcode: plateBarcode,
+          comments: "",
+          plateGeometryId: 8,
+          plateId: 14,
+          plateStatusId: 3,
+          ...mockAuditInfo,
+        },
+        wells: [],
+      });
+
+      const { logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        upload: getMockStateWithHistory({
+          [uploadRowKey1]: { file: uploadRowKey1 },
+          [uploadRowKey2]: { file: uploadRowKey2 },
+        }),
+      });
+
+      // act
+      store.dispatch(
+        updateUploadRows([uploadRowKey1, uploadRowKey2], {
+          [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+          [AnnotationName.IMAGING_SESSION]: [imagingSession],
+        })
+      );
+      await logicMiddleware.whenComplete();
+
+      // assert - imaging session is not wiped by the per-row plate barcode
+      // re-dispatch
+      const upload = getUpload(store.getState());
+      expect(
+        upload[uploadRowKey1][AnnotationName.IMAGING_SESSION]
+      ).to.deep.equal([imagingSession]);
+      expect(
+        upload[uploadRowKey2][AnnotationName.IMAGING_SESSION]
+      ).to.deep.equal([imagingSession]);
+    });
   });
   describe("saveUploadDraftLogic", () => {
     it("shows save dialog and does not dispatch saveUploadDraftSuccess if user cancels save", async () => {


### PR DESCRIPTION
### Description
Applying a mass edit that set Plate Barcode + Imaging Session together left Imaging Session blank. The event dispatched for well autofill mistakenly reset Imaging Session whenever a plate barcode was entered and imaging session was being reset.

Additionally, selecting a template with Imaging Session as one of its columns was crashing FUA.

### Files Changed

- src/renderer/state/upload/reducer.ts: When you change the plate barcode, Imaging Session and Well normally get cleared. Now, if the same update also sets a new Imaging Session or Well, that value is kept instead of being wiped. (UPDATE_UPLOAD_ROWS already worked this way)
- src/renderer/state/upload/logics.ts: Make well autofill still fire without dropping any values
- src/renderer/state/upload/test/logics.test.ts: Added test: "preserves imaging session when applied alongside plate barcode"
-  src/renderer/containers/CustomDataTable/selectors.tsx: Skip any template annotation whose name matches a built-in plate column (like Imaging Session), so the same column doesn't get added twice.

### Testing
Tested locally to verify that applying mass edit now works for Imaging Session



