### PR TITLE
Imaging session entered now refreshes well

### DIFF
--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -365,73 +365,103 @@ const updateUploadLogic = createLogic({
     done: ReduxLogicDoneCb
   ) => {
     const upload = deps.action.payload.upload || deps.action.payload;
+    const fileKey: string | undefined = deps.action.payload.key;
+    const modifiedAnnotations = Object.keys(upload);
 
-    // If a plate barcode is being updated check for imaging sessions
-    const plateBarcode = upload[AnnotationName.PLATE_BARCODE]?.[0];
-    if (plateBarcode) {
-      const plateBarcodeToPlates = getPlateBarcodeToPlates(deps.getState());
-      let updatedPlateBarcodeToPlates = plateBarcodeToPlates;
-      // Avoid re-querying for the imaging sessions if this
-      // plate barcode has been selected before
-      if (!Object.keys(plateBarcodeToPlates).includes(plateBarcode)) {
-        const imagingSessionsForPlateBarcode =
-          await deps.labkeyClient.findImagingSessionsByPlateBarcode(
-            plateBarcode
-          );
-        const imagingSessionsWithPlateInfo: PlateAtImagingSession[] =
-          await Promise.all(
-            imagingSessionsForPlateBarcode.map(async (is) => {
-              const { wells } = await deps.mmsClient.getPlate(
-                plateBarcode,
-                is["ImagingSessionId"]
-              );
+    // Plate wells depend on both the plate barcode and the imaging session
+    // (a barcode may exist only as imaging-session plates, in which case the
+    // wells aren't known until an imaging session is selected), so react to
+    // updates of either
+    if (
+      !modifiedAnnotations.includes(AnnotationName.PLATE_BARCODE) &&
+      !modifiedAnnotations.includes(AnnotationName.IMAGING_SESSION)
+    ) {
+      done();
+      return;
+    }
 
-              return {
-                wells,
-                imagingSessionId: is["ImagingSessionId"],
-                name: is["ImagingSessionId/Name"],
-              };
-            })
-          );
+    // The update may contain only one of plate barcode / imaging session;
+    // fall back to what is already stored for this row (or the mass edit row)
+    const state = deps.getState();
+    const storedRow = fileKey
+      ? getUpload(state)[fileKey]
+      : getMassEditRow(state);
+    const plateBarcode =
+      upload[AnnotationName.PLATE_BARCODE]?.[0] ??
+      storedRow?.[AnnotationName.PLATE_BARCODE]?.[0];
+    if (!plateBarcode) {
+      done();
+      return;
+    }
+    const imagingSessionName =
+      upload[AnnotationName.IMAGING_SESSION]?.[0] ??
+      storedRow?.[AnnotationName.IMAGING_SESSION]?.[0];
 
-        // If the barcode has no imaging sessions, find info of plate without
-        if (!imagingSessionsWithPlateInfo.length) {
-          const { wells } = await deps.mmsClient.getPlate(plateBarcode);
-          imagingSessionsWithPlateInfo.push({ wells });
-        }
+    const plateBarcodeToPlates = getPlateBarcodeToPlates(state);
+    let updatedPlateBarcodeToPlates = plateBarcodeToPlates;
+    const platesForBarcode = plateBarcodeToPlates[plateBarcode];
+    // Avoid re-querying for the imaging sessions if this plate barcode has
+    // been selected before, unless the entry is stale (e.g. restored from a
+    // draft) and doesn't know about the selected imaging session
+    const isCacheMissingImagingSession =
+      !!imagingSessionName &&
+      !platesForBarcode?.some((p) => p.name === imagingSessionName);
+    if (!platesForBarcode || isCacheMissingImagingSession) {
+      const imagingSessionsForPlateBarcode =
+        await deps.labkeyClient.findImagingSessionsByPlateBarcode(plateBarcode);
+      const imagingSessionsWithPlateInfo: PlateAtImagingSession[] =
+        await Promise.all(
+          imagingSessionsForPlateBarcode.map(async (is) => {
+            const { wells } = await deps.mmsClient.getPlate(
+              plateBarcode,
+              is["ImagingSessionId"]
+            );
 
-        updatedPlateBarcodeToPlates = {
-          ...plateBarcodeToPlates,
-          [plateBarcode]: imagingSessionsWithPlateInfo,
-        };
-        dispatch(setPlateBarcodeToPlates(updatedPlateBarcodeToPlates));
+            return {
+              wells,
+              imagingSessionId: is["ImagingSessionId"],
+              name: is["ImagingSessionId/Name"],
+            };
+          })
+        );
+
+      // If the barcode has no imaging sessions, find info of plate without
+      if (!imagingSessionsWithPlateInfo.length) {
+        const { wells } = await deps.mmsClient.getPlate(plateBarcode);
+        imagingSessionsWithPlateInfo.push({ wells });
       }
 
-      // autoselect well if row and col data available from mxs
-      const fileKey = deps.action.payload.key;
-      const mxsData = deps.getState().metadataExtraction[fileKey]?.metadata;
-      const rowValue = mxsData?.["Row"]?.value;
-      const colValue = mxsData?.["Column"]?.value;
+      updatedPlateBarcodeToPlates = {
+        ...plateBarcodeToPlates,
+        [plateBarcode]: imagingSessionsWithPlateInfo,
+      };
+      dispatch(setPlateBarcodeToPlates(updatedPlateBarcodeToPlates));
+    }
 
-      if (rowValue !== undefined && colValue !== undefined) {
-        // row and col are 1-indexed in metadata, convert to 0-indexed
-        const row = Number(rowValue) - 1;
-        const col = Number(colValue) - 1;
-        const plates = updatedPlateBarcodeToPlates[plateBarcode];
-        // this should match the logic in WellCell
-        const imagingSessionName = upload[AnnotationName.IMAGING_SESSION]?.[0];
-        const plate = plates?.find((p) =>
-          imagingSessionName ? p.name === imagingSessionName : !p.name
+    // autoselect well if row and col data available from mxs
+    const mxsData = fileKey
+      ? deps.getState().metadataExtraction[fileKey]?.metadata
+      : undefined;
+    const rowValue = mxsData?.["Row"]?.value;
+    const colValue = mxsData?.["Column"]?.value;
+
+    if (fileKey && rowValue !== undefined && colValue !== undefined) {
+      // row and col are 1-indexed in metadata, convert to 0-indexed
+      const row = Number(rowValue) - 1;
+      const col = Number(colValue) - 1;
+      const plates = updatedPlateBarcodeToPlates[plateBarcode];
+      // this should match the logic in WellCell
+      const plate = plates?.find((p) =>
+        imagingSessionName ? p.name === imagingSessionName : !p.name
+      );
+      const well = plate?.wells.find((w) => w.row === row && w.col === col);
+      if (well) {
+        dispatch(
+          updateUpload(fileKey, {
+            [AnnotationName.WELL]: [well.wellId],
+            autofilledFields: [AnnotationName.WELL],
+          })
         );
-        const well = plate?.wells.find((w) => w.row === row && w.col === col);
-        if (well) {
-          dispatch(
-            updateUpload(fileKey, {
-              [AnnotationName.WELL]: [well.wellId],
-              autofilledFields: [AnnotationName.WELL],
-            })
-          );
-        }
       }
     }
 
@@ -490,14 +520,15 @@ const updateUploadRowsLogic = createLogic({
       AnnotationName.PLATE_BARCODE
     ]?.[0]; // update contains plate barcode value, or undefined if no plateBarcode value
 
+    // Preserve any imaging session / well provided in the same update (e.g.
+    // a mass edit) so the plate barcode re-dispatch below does not wipe them
+    // out via the UPDATE_UPLOAD reset logic.
+    const imagingSession = (metadataUpdate as Partial<FileModel>)[
+      AnnotationName.IMAGING_SESSION
+    ];
+    const well = (metadataUpdate as Partial<FileModel>)[AnnotationName.WELL];
+
     if (plateBarcode) {
-      // Preserve any imaging session / well provided in the same update (e.g.
-      // a mass edit) so the plate barcode re-dispatch below does not wipe them
-      // out via the UPDATE_UPLOAD reset logic.
-      const imagingSession = (metadataUpdate as Partial<FileModel>)[
-        AnnotationName.IMAGING_SESSION
-      ];
-      const well = (metadataUpdate as Partial<FileModel>)[AnnotationName.WELL];
       for (const fileKey of uploadKeys) {
         // dispatch update to plate barcode for each row
         // which will trigger well autofill
@@ -507,6 +538,21 @@ const updateUploadRowsLogic = createLogic({
             ...(imagingSession !== undefined && {
               [AnnotationName.IMAGING_SESSION]: imagingSession,
             }),
+            ...(well !== undefined && {
+              [AnnotationName.WELL]: well,
+            }),
+          })
+        );
+      }
+    } else if (imagingSession?.length) {
+      // An imaging session applied without a barcode (e.g. a mass edit onto
+      // rows that already have barcodes) also determines the wells, so
+      // re-dispatch per row to trigger well autofill against each row's
+      // own plate barcode
+      for (const fileKey of uploadKeys) {
+        dispatch(
+          updateUpload(fileKey, {
+            [AnnotationName.IMAGING_SESSION]: imagingSession,
             ...(well !== undefined && {
               [AnnotationName.WELL]: well,
             }),

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -399,41 +399,44 @@ const updateUploadLogic = createLogic({
 
     const plateBarcodeToPlates = getPlateBarcodeToPlates(state);
     let updatedPlateBarcodeToPlates = plateBarcodeToPlates;
-    const platesForBarcode = plateBarcodeToPlates[plateBarcode];
+    const cachedPlates = plateBarcodeToPlates[plateBarcode];
     // Avoid re-querying for the imaging sessions if this plate barcode has
     // been selected before, unless the entry is stale (e.g. restored from a
     // draft) and doesn't know about the selected imaging session
     const isCacheMissingImagingSession =
       !!imagingSessionName &&
-      !platesForBarcode?.some((p) => p.name === imagingSessionName);
-    if (!platesForBarcode || isCacheMissingImagingSession) {
+      !cachedPlates?.some((p) => p.name === imagingSessionName);
+    if (!cachedPlates || isCacheMissingImagingSession) {
       const imagingSessionsForPlateBarcode =
         await deps.labkeyClient.findImagingSessionsByPlateBarcode(plateBarcode);
-      const imagingSessionsWithPlateInfo: PlateAtImagingSession[] =
-        await Promise.all(
-          imagingSessionsForPlateBarcode.map(async (is) => {
-            const { wells } = await deps.mmsClient.getPlate(
-              plateBarcode,
-              is["ImagingSessionId"]
-            );
+      // A barcode resolves to one plate per imaging session it was imaged at
+      const platesForBarcode: PlateAtImagingSession[] = await Promise.all(
+        imagingSessionsForPlateBarcode.map(async (is) => {
+          const { wells } = await deps.mmsClient.getPlate(
+            plateBarcode,
+            is["ImagingSessionId"]
+          );
 
-            return {
-              wells,
-              imagingSessionId: is["ImagingSessionId"],
-              name: is["ImagingSessionId/Name"],
-            };
-          })
-        );
+          return {
+            wells,
+            imagingSessionId: is["ImagingSessionId"],
+            name: is["ImagingSessionId/Name"],
+          };
+        })
+      );
 
-      // If the barcode has no imaging sessions, find info of plate without
-      if (!imagingSessionsWithPlateInfo.length) {
+      // A barcode with no imaging sessions has a single session-less plate,
+      // represented as an entry without a name/imagingSessionId so consumers
+      // (well autofill below, WellCell) can match it when no imaging session
+      // is selected
+      if (!platesForBarcode.length) {
         const { wells } = await deps.mmsClient.getPlate(plateBarcode);
-        imagingSessionsWithPlateInfo.push({ wells });
+        platesForBarcode.push({ wells });
       }
 
       updatedPlateBarcodeToPlates = {
         ...plateBarcodeToPlates,
-        [plateBarcode]: imagingSessionsWithPlateInfo,
+        [plateBarcode]: platesForBarcode,
       };
       dispatch(setPlateBarcodeToPlates(updatedPlateBarcodeToPlates));
     }

--- a/src/renderer/state/upload/test/logics.test.ts
+++ b/src/renderer/state/upload/test/logics.test.ts
@@ -1087,6 +1087,177 @@ describe("Upload logics", () => {
         getUpload(store.getState())[uploadRowKey][AnnotationName.PLATE_BARCODE]
       ).to.deep.equal([plateBarcode]);
     });
+
+    it("autoselects well when imaging session is selected after plate barcode", async () => {
+      // Arrange - the barcode only exists as imaging session plates, so no
+      // well could be autofilled when the barcode was entered; selecting the
+      // imaging session afterwards should trigger the autofill
+      const plateBarcode = "490109230";
+      const imagingSessionName = "imaging session 9";
+      const { store, logicMiddleware } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        metadata: {
+          ...nonEmptyStateForInitiatingUpload.metadata,
+          plateBarcodeToPlates: {
+            [plateBarcode]: [
+              {
+                name: imagingSessionName,
+                imagingSessionId: 9,
+                wells: [
+                  {
+                    row: 0,
+                    col: 2,
+                    wellId: 102,
+                    plateId: 14,
+                    cellPopulations: [],
+                    solutions: [],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        metadataExtraction: {
+          [uploadRowKey]: {
+            loading: false,
+            metadata: {
+              Row: { annotation_id: 1, value: 1 },
+              Column: { annotation_id: 2, value: 3 },
+            },
+          },
+        },
+        template: {
+          ...mockTemplateStateBranch,
+          appliedTemplate: {
+            ...mockTemplateWithManyValues,
+            annotations: [mockTextAnnotation],
+          },
+        },
+        upload: getMockStateWithHistory({
+          [uploadRowKey]: {
+            [mockTextAnnotation.name]: [],
+            file: "/path/to/file3",
+            [AnnotationName.NOTES]: [],
+            templateId: 8,
+            [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+            [AnnotationName.WELL]: [],
+          },
+        }),
+      });
+
+      // Act
+      store.dispatch(
+        updateUpload(uploadRowKey, {
+          [AnnotationName.IMAGING_SESSION]: [imagingSessionName],
+        })
+      );
+      await logicMiddleware.whenComplete();
+
+      // Assert
+      // Row=1, Col=3 -> 0, 2 -> which is wellId 102
+      expect(
+        getUpload(store.getState())[uploadRowKey][AnnotationName.WELL]
+      ).to.deep.equal([102]);
+      // The cached plate info was used, no re-query necessary
+      expect(labkeyClient.findImagingSessionsByPlateBarcode.called).to.be.false;
+    });
+
+    it("re-queries plate info when cached plates do not include the selected imaging session", async () => {
+      // Arrange - the cached entry for the barcode is stale (e.g. restored
+      // from a draft saved before the imaging session existed)
+      const plateBarcode = "490109230";
+      const imagingSessionName = "imaging session 9";
+      const { store, logicMiddleware } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        metadata: {
+          ...nonEmptyStateForInitiatingUpload.metadata,
+          plateBarcodeToPlates: {
+            [plateBarcode]: [{ wells: [] }],
+          },
+        },
+        metadataExtraction: {
+          [uploadRowKey]: {
+            loading: false,
+            metadata: {
+              Row: { annotation_id: 1, value: 1 },
+              Column: { annotation_id: 2, value: 3 },
+            },
+          },
+        },
+        template: {
+          ...mockTemplateStateBranch,
+          appliedTemplate: {
+            ...mockTemplateWithManyValues,
+            annotations: [mockTextAnnotation],
+          },
+        },
+        upload: getMockStateWithHistory({
+          [uploadRowKey]: {
+            [mockTextAnnotation.name]: [],
+            file: "/path/to/file3",
+            [AnnotationName.NOTES]: [],
+            templateId: 8,
+            [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+            [AnnotationName.WELL]: [],
+          },
+        }),
+      });
+      labkeyClient.findImagingSessionsByPlateBarcode.resolves([
+        { ImagingSessionId: 9, "ImagingSessionId/Name": imagingSessionName },
+      ]);
+      mmsClient.getPlate.resolves({
+        plate: {
+          barcode: plateBarcode,
+          comments: "",
+          plateGeometryId: 8,
+          plateId: 14,
+          plateStatusId: 3,
+          ...mockAuditInfo,
+        },
+        wells: [
+          {
+            row: 0,
+            col: 2,
+            wellId: 102,
+            plateId: 14,
+            cellPopulations: [],
+            solutions: [],
+          },
+        ],
+      });
+
+      // Act
+      store.dispatch(
+        updateUpload(uploadRowKey, {
+          [AnnotationName.IMAGING_SESSION]: [imagingSessionName],
+        })
+      );
+      await logicMiddleware.whenComplete();
+
+      // Assert
+      expect(labkeyClient.findImagingSessionsByPlateBarcode.called).to.be.true;
+      expect(getPlateBarcodeToPlates(store.getState())).to.deep.equal({
+        [plateBarcode]: [
+          {
+            name: imagingSessionName,
+            imagingSessionId: 9,
+            wells: [
+              {
+                row: 0,
+                col: 2,
+                wellId: 102,
+                plateId: 14,
+                cellPopulations: [],
+                solutions: [],
+              },
+            ],
+          },
+        ],
+      });
+      expect(
+        getUpload(store.getState())[uploadRowKey][AnnotationName.WELL]
+      ).to.deep.equal([102]);
+    });
   });
 
   describe("updateUploadRowsLogic", () => {
@@ -1296,6 +1467,87 @@ describe("Upload logics", () => {
       expect(
         upload[uploadRowKey2][AnnotationName.IMAGING_SESSION]
       ).to.deep.equal([imagingSession]);
+    });
+
+    it("autofills wells per row when imaging session is applied without plate barcode", async () => {
+      // arrange - reproduces a mass edit applying only an imaging session to
+      // rows that already have plate barcodes
+      const plateBarcode = "3500004832";
+      const imagingSession = "imaging session 9";
+      const uploadRowKey1 = "/path/to/file1";
+      const uploadRowKey2 = "/path/to/file2";
+      const platesForBarcode = [
+        {
+          name: imagingSession,
+          imagingSessionId: 9,
+          wells: [
+            {
+              row: 0,
+              col: 2,
+              wellId: 102,
+              plateId: 14,
+              cellPopulations: [],
+              solutions: [],
+            },
+          ],
+        },
+      ];
+
+      const { logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        metadata: {
+          ...nonEmptyStateForInitiatingUpload.metadata,
+          plateBarcodeToPlates: {
+            [plateBarcode]: platesForBarcode,
+          },
+        },
+        metadataExtraction: {
+          [uploadRowKey1]: {
+            loading: false,
+            metadata: {
+              Row: { annotation_id: 1, value: 1 },
+              Column: { annotation_id: 2, value: 3 },
+            },
+          },
+          [uploadRowKey2]: {
+            loading: false,
+            metadata: {
+              Row: { annotation_id: 1, value: 1 },
+              Column: { annotation_id: 2, value: 3 },
+            },
+          },
+        },
+        upload: getMockStateWithHistory({
+          [uploadRowKey1]: {
+            file: uploadRowKey1,
+            [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+          },
+          [uploadRowKey2]: {
+            file: uploadRowKey2,
+            [AnnotationName.PLATE_BARCODE]: [plateBarcode],
+          },
+        }),
+      });
+
+      // act
+      store.dispatch(
+        updateUploadRows([uploadRowKey1, uploadRowKey2], {
+          [AnnotationName.IMAGING_SESSION]: [imagingSession],
+        })
+      );
+      await logicMiddleware.whenComplete();
+
+      // assert - each row got the imaging session and its well autofilled
+      // from its own plate barcode
+      const upload = getUpload(store.getState());
+      expect(
+        upload[uploadRowKey1][AnnotationName.IMAGING_SESSION]
+      ).to.deep.equal([imagingSession]);
+      expect(
+        upload[uploadRowKey2][AnnotationName.IMAGING_SESSION]
+      ).to.deep.equal([imagingSession]);
+      expect(upload[uploadRowKey1][AnnotationName.WELL]).to.deep.equal([102]);
+      expect(upload[uploadRowKey2][AnnotationName.WELL]).to.deep.equal([102]);
     });
   });
   describe("saveUploadDraftLogic", () => {


### PR DESCRIPTION
To fix https://github.com/aics-int/aics-file-upload-app/issues/295

Previously, FUA assumed a plain plate (not associated with an imaging session) always exists for a barcode. Hannah reported this issue with FUA on a barcode which only had plates associated with imaging sessions, which broke the app.

- Autofill could never fire for this barcode. The well autofill code only ran when the update contained a plate barcode.
- Well cell stayed greyed out and did not re-trigger when an imaging session was selected

This PR fixes these issues
`src/renderer/state/upload/logics.ts`: plate lookup + well autofill now triggers on imaging session selection, and mass editor fixed to have the same behavior

`src/renderer/state/upload/test/logics.test.ts` : some tests for this new code

