### PR TITLE
Loading wheel for mass editor and drag and drop applies

### DIFF
--- a/src/renderer/containers/AddMetadataPage/index.tsx
+++ b/src/renderer/containers/AddMetadataPage/index.tsx
@@ -8,6 +8,7 @@ import { MainProcessEvents, SCHEMA_SYNONYM } from "../../../shared/constants";
 import TemplateSearch from "../../components/TemplateSearch";
 import { AnnotationName } from "../../constants";
 import {
+  getIsLoading,
   getRequestsInProgress,
   getUploadError,
 } from "../../state/feedback/selectors";
@@ -33,6 +34,7 @@ export default function AddMetadataPage() {
   const appliedTemplate = useSelector(getAppliedTemplate);
   const imagingSessions = useSelector(getImagingSessions);
   const isReadOnly = useSelector(getAreSelectedUploadsInFlight);
+  const isApplyingMassEdit = useSelector(getIsLoading);
   const requestsInProgress = useSelector(getRequestsInProgress);
   const uploadError = useSelector(getUploadError);
   const validationErrors = useSelector(getUploadValidationErrors);
@@ -73,6 +75,14 @@ export default function AddMetadataPage() {
 
   return (
     <div className={styles.page}>
+      {isApplyingMassEdit && (
+        <div className={styles.loadingOverlay}>
+          <div className={styles.spinContainer}>
+            <div>Applying changes. This may take a moment...</div>
+            <Spin />
+          </div>
+        </div>
+      )}
       <div>
         {!selectedUploads.length && ( // If we're adding new files, not editing ones that have been uploaded.
           <Button

--- a/src/renderer/containers/AddMetadataPage/styles.pcss
+++ b/src/renderer/containers/AddMetadataPage/styles.pcss
@@ -32,6 +32,16 @@
   width: 100%;
 }
 
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  z-index: 500;
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
 .spin-container {
   height: 100%;
   width: 100%;

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -122,7 +122,7 @@ const startMassEditLogic = createLogic({
 });
 
 const applyMassEditLogic = createLogic({
-  process: (
+  process: async (
     { ctx }: ReduxLogicProcessDependencies,
     dispatch: ReduxLogicNextCb,
     done: ReduxLogicDoneCb
@@ -137,6 +137,15 @@ const applyMassEditLogic = createLogic({
         }),
       }),
       {}
+    );
+    // mass edit blocks the UI thread while metadata is extracted for all the files
+    // so we  show a loading indicator and wait for it to render before starting
+    // updateUploadRowsLogic will later stop the indicator when the changes are done
+    dispatch(startLoading());
+    await new Promise((resolve) =>
+      typeof requestAnimationFrame === "function"
+        ? requestAnimationFrame(() => requestAnimationFrame(resolve))
+        : setTimeout(resolve, 0)
     );
     dispatch(updateUploadRows(rowIds, rowData));
     done();

--- a/src/renderer/state/selection/logics.ts
+++ b/src/renderer/state/selection/logics.ts
@@ -121,6 +121,20 @@ const startMassEditLogic = createLogic({
   type: START_MASS_EDIT,
 });
 
+/**
+ * shows a loading indicator which spins while the caller blocks the UI thread
+ * used for mass edit applies and drag and drop applies across many files
+ * the caller need to call stopLoading once the updates are applied
+ */
+async function startLoadingAndAwaitPaint(dispatch: ReduxLogicNextCb) {
+  dispatch(startLoading());
+  await new Promise((resolve) =>
+    typeof requestAnimationFrame === "function"
+      ? requestAnimationFrame(() => requestAnimationFrame(resolve))
+      : setTimeout(resolve, 0)
+  );
+}
+
 const applyMassEditLogic = createLogic({
   process: async (
     { ctx }: ReduxLogicProcessDependencies,
@@ -138,15 +152,9 @@ const applyMassEditLogic = createLogic({
       }),
       {}
     );
-    // mass edit blocks the UI thread while metadata is extracted for all the files
-    // so we  show a loading indicator and wait for it to render before starting
-    // updateUploadRowsLogic will later stop the indicator when the changes are done
-    dispatch(startLoading());
-    await new Promise((resolve) =>
-      typeof requestAnimationFrame === "function"
-        ? requestAnimationFrame(() => requestAnimationFrame(resolve))
-        : setTimeout(resolve, 0)
-    );
+    // mass edit blocks the UI thread while every row is updated, show loading wheel
+    // updateUploadRowsLogic stops the indicator once the changes are done
+    await startLoadingAndAwaitPaint(dispatch);
     dispatch(updateUploadRows(rowIds, rowData));
     done();
   },
@@ -164,7 +172,7 @@ const applyMassEditLogic = createLogic({
 });
 
 const stopCellDragLogic = createLogic({
-  process: (
+  process: async (
     { ctx, getState }: ReduxLogicProcessDependencies,
     dispatch: ReduxLogicNextCb,
     done: ReduxLogicDoneCb
@@ -183,6 +191,9 @@ const stopCellDragLogic = createLogic({
 
       // drag to copy protection against overwriting rows already autofilled by mxs
       if (notAutofilledRowIds.length) {
+        // drag to copy blocks the UI thread just like a mass edi
+        // updateUploadRowsLogic stops the indicator once the changes are done
+        await startLoadingAndAwaitPaint(dispatch);
         dispatch(updateUploadRows(notAutofilledRowIds, { [columnId]: value }));
       }
     }

--- a/src/renderer/state/selection/test/logics.test.ts
+++ b/src/renderer/state/selection/test/logics.test.ts
@@ -377,6 +377,42 @@ describe("Selection logics", () => {
 
       // Assert
       expect(actions.includesType(UPDATE_UPLOAD_ROWS)).to.be.false;
+      // No rows to update, so the loading indicator never shows
+      expect(actions.includesType(feedback.actions.startLoading().type)).to.be
+        .false;
+    });
+
+    it("shows a loading indicator while the dragged value is applied", async () => {
+      // Arrange
+      const cellAtDragStart = {
+        rowId: "14",
+        columnId: "Is Aligned?",
+        rowIndex: 2,
+      };
+      const { actions, logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        selection: {
+          ...mockSelection,
+          cellAtDragStart,
+          rowsSelectedForDragEvent: [{ id: "21", index: 0 }],
+        },
+        upload: getMockStateWithHistory({
+          [cellAtDragStart.rowId]: {
+            file: "/some/path/to/a/file.txt",
+            [cellAtDragStart.columnId]: "false",
+          },
+        }),
+      });
+
+      // Act
+      store.dispatch(stopCellDrag());
+      await logicMiddleware.whenComplete();
+
+      // Assert
+      expect(actions.includesType(feedback.actions.startLoading().type)).to.be
+        .true;
+      // updateUploadRowsLogic stops the indicator once the rows are updated
+      expect(feedback.selectors.getIsLoading(store.getState())).to.be.false;
     });
   });
 });

--- a/src/renderer/state/selection/test/logics.test.ts
+++ b/src/renderer/state/selection/test/logics.test.ts
@@ -218,6 +218,28 @@ describe("Selection logics", () => {
         )
       ).to.be.true;
     });
+
+    it("shows a loading indicator while the edit is applied", async () => {
+      // Arrange
+      const { actions, logicMiddleware, store } = createMockReduxStore({
+        ...nonEmptyStateForInitiatingUpload,
+        selection: {
+          ...mockSelection,
+          rowsSelectedForMassEdit: ["1", "2"],
+          massEditRow: { color: ["blue"] },
+        },
+      });
+
+      // Act
+      store.dispatch(applyMassEdit());
+      await logicMiddleware.whenComplete();
+
+      // Assert
+      expect(actions.includesType(feedback.actions.startLoading().type)).to.be
+        .true;
+      // updateUploadRowsLogic stops the indicator once the rows are updated
+      expect(feedback.selectors.getIsLoading(store.getState())).to.be.false;
+    });
   });
 
   describe("stopCellDragLogic", () => {

--- a/src/renderer/state/upload/logics.ts
+++ b/src/renderer/state/upload/logics.ts
@@ -19,7 +19,7 @@ import {
   splitTrimAndFilter,
 } from "../../util";
 import { requestFailed } from "../actions";
-import { setErrorAlert } from "../feedback/actions";
+import { setErrorAlert, stopLoading } from "../feedback/actions";
 import { setPlateBarcodeToPlates } from "../metadata/actions";
 import {
   getAnnotations,
@@ -564,6 +564,8 @@ const updateUploadRowsLogic = createLogic({
       }
     }
 
+    // stop the loading wheel
+    dispatch(stopLoading());
     done();
   },
   transform: (


### PR DESCRIPTION
**Problem**
When a user does a mass editor or drag and drop apply for many files, it looks like theres a short freeze while the edit is written into every row and the table renders.

**My solution**
I added a loading wheel that appears right after the edits are applied, and the table re renders happen. the loading wheel stays up through the UI blocking part, and goes down once the renders finish.

This loading wheel finishes before the metadata extraction plate barcode lookups happen per file, but that already has a loading indicator for each row and the UI is not frozen during this so I thought this would be the best solution.

used this as a resource: https://medium.com/@owencm/one-weird-trick-to-performant-touch-response-animations-with-react-9fe4a0838116

<img width="1512" height="982" alt="Screenshot 2026-08-12 at 8 05 18 AM" src="https://github.com/user-attachments/assets/be3246d4-20e7-4d63-baff-8d4ea7ef8ab4" />

**Changes**
src/renderer/state/selection/logics.ts: `startLoadingAndAwaitPaint` is the most important thing here. It shows the UI spinner, waits for that to render before returning so we're guaranteed to show the loading wheel before other callers block the UI thread. [Used the above medium link as a resource for this](https://medium.com/@owencm/one-weird-trick-to-performant-touch-response-animations-with-react-9fe4a0838116)

src/renderer/state/upload/logics.ts: dispatches an event that stops the loading wheel 

src/renderer/containers/AddMetadataPage/index.tsx: shows the loading wheel on the metadata page

src/renderer/containers/AddMetadataPage/styles.pcss: style for the loading wheel (claude helped me with this)

src/renderer/state/selection/test/logics.test.ts: some tests from claude





