### PR TITLE
Windows mount paths getting rejected fix

### DIFF
--- a/src/renderer/util/index.ts
+++ b/src/renderer/util/index.ts
@@ -36,19 +36,25 @@ const canUserRead = async (filePath: string): Promise<boolean> => {
 };
 
 /**
- * Converts an osx mount path to a VAST path starting with /allen.
- * removes any prefix before /allen (ex: /Volumes/allen/... -> /allen/...).
+ * Converts an osx mount path or Windows path to a VAST path starting with /allen.
+ * Removes any prefix before /allen (ex: /Volumes/allen/... -> /allen/...,
+ * \\allen\aics\... -> /allen/aics/...).
  * Throws an error if /allen is not found in the path.
  */
 export function convertToVastPath(filePath: string): string {
   const VAST_PREFIX = "/allen/";
-  const allenIndex = filePath.toLowerCase().indexOf(VAST_PREFIX);
+  // Normalize Windows paths: backslashes -> forward slashes
+  // (ex: \\allen\aics\... -> //allen/aics/...)
+  const normalized = filePath.replace(/\\/g, "/");
+  const allenIndex = normalized.toLowerCase().indexOf(VAST_PREFIX);
 
   if (allenIndex === -1) {
     throw new Error("You must select files that are on VAST");
   }
 
-  return filePath.slice(allenIndex);
+  // Slice from the match, forcing the mount component to lowercase "allen"
+  // (Windows generates both "Allen" and "ALLEN" in the wild)
+  return VAST_PREFIX + normalized.slice(allenIndex + VAST_PREFIX.length);
 }
 
 /**

--- a/src/renderer/util/test/index.test.ts
+++ b/src/renderer/util/test/index.test.ts
@@ -96,6 +96,27 @@ describe("General utilities", () => {
       );
     });
 
+    it("converts Windows UNC paths with backslashes", () => {
+      expect(
+        convertToVastPath("\\\\allen\\aics\\users\\sara.carlson\\test.czi")
+      ).to.equal("/allen/aics/users/sara.carlson/test.czi");
+    });
+
+    it("converts Windows mapped-drive paths containing allen", () => {
+      expect(convertToVastPath("Z:\\allen\\aics\\test.czi")).to.equal(
+        "/allen/aics/test.czi"
+      );
+    });
+
+    it("forces the allen mount component to lowercase", () => {
+      expect(convertToVastPath("\\\\ALLEN\\aics\\test.czi")).to.equal(
+        "/allen/aics/test.czi"
+      );
+      expect(convertToVastPath("/Volumes/Allen/aics/test.czi")).to.equal(
+        "/allen/aics/test.czi"
+      );
+    });
+
     it("throws 'You must select files that are on VAST' when /allen is absent", () => {
       expect(() => convertToVastPath("/abc/cde/xyz/test.czi")).to.throw(
         "You must select files that are on VAST"


### PR DESCRIPTION
Previous fix for mac vast paths caused this issue- windows mount paths are not getting validated as valid vast paths, this fixes that issue.